### PR TITLE
Add comprehensive testing suite and patch error handling gaps

### DIFF
--- a/src/ecs/engine.ts
+++ b/src/ecs/engine.ts
@@ -78,6 +78,10 @@ export class Engine {
     this.eventBus.on(eventType, handler);
   }
 
+  off(eventType: string, handler: (event: ECSEvent) => void | Promise<void>): void {
+    this.eventBus.off(eventType, handler);
+  }
+
   emit(event: ECSEvent): void {
     this.store.logEvent(event);
     this.eventBus.emit(event);

--- a/src/systems/judge.ts
+++ b/src/systems/judge.ts
@@ -42,6 +42,13 @@ export default function createJudge(engine: Engine): System {
         parsed = JudgementSchema.safeParse(JSON.parse(response.content));
       } catch {
         engine.getLogger().warn({ content: response.content }, 'TheJudge: failed to parse response');
+        engine.emit({
+          type: 'system:error',
+          entityId: event.entityId,
+          data: { system: 'TheJudge', error: 'Failed to parse LLM response as JSON' },
+          source: 'TheJudge',
+          timestamp: Date.now(),
+        });
         return;
       }
 

--- a/src/systems/recursive-improver.ts
+++ b/src/systems/recursive-improver.ts
@@ -293,8 +293,11 @@ async function runNextIteration(
   // Route the experiment for execution — the experiment goes through the normal
   // system-selector → execution → judge pipeline. We listen for the judgement
   // back via task:judged on this entity, then evaluate it in the loop context.
-  engine.on('task:judged', async function onJudged(judgedEvent) {
+  const onJudged = async (judgedEvent: import('../ecs/types.js').ECSEvent) => {
     if (judgedEvent.entityId !== experimentId) return;
+
+    // Unregister this one-shot listener
+    engine.off('task:judged', onJudged);
 
     // Evaluate the experiment result in the context of the improvement loop
     const judgement = engine.getComponent(experimentId, 'Judgement');
@@ -353,7 +356,8 @@ async function runNextIteration(
       source: 'RecursiveImprover',
       timestamp: Date.now(),
     });
-  });
+  };
+  engine.on('task:judged', onJudged);
 
   // Route the experiment through the standard pipeline
   engine.emit({

--- a/src/systems/system-selector.ts
+++ b/src/systems/system-selector.ts
@@ -54,6 +54,15 @@ export default function createSystemSelector(engine: Engine): System {
           source: 'SystemSelector',
           timestamp: Date.now(),
         });
+      } else {
+        engine.getLogger().warn({ entityId: event.entityId }, 'SystemSelector: no system selected by LLM');
+        engine.emit({
+          type: 'system:error',
+          entityId: event.entityId,
+          data: { system: 'SystemSelector', error: 'LLM did not select a system' },
+          source: 'SystemSelector',
+          timestamp: Date.now(),
+        });
       }
     },
   };

--- a/src/systems/task-generator.ts
+++ b/src/systems/task-generator.ts
@@ -46,6 +46,13 @@ export default function createTaskGenerator(engine: Engine): System {
         parsed = TaskListSchema.safeParse(JSON.parse(response.content));
       } catch {
         engine.getLogger().warn({ content: response.content }, 'TaskGenerator: failed to parse response');
+        engine.emit({
+          type: 'system:error',
+          entityId: event.entityId,
+          data: { system: 'TaskGenerator', error: 'Failed to parse LLM response as JSON' },
+          source: 'TaskGenerator',
+          timestamp: Date.now(),
+        });
         return;
       }
 

--- a/tests/container/ipc.test.ts
+++ b/tests/container/ipc.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { IPC } from '../../src/container/ipc.js';
+
+describe('IPC', () => {
+  let ipcDir: string;
+
+  beforeEach(() => {
+    ipcDir = join(tmpdir(), `chippr-test-ipc-${Date.now()}`);
+  });
+
+  afterEach(() => {
+    if (existsSync(ipcDir)) {
+      rmSync(ipcDir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates IPC directory if not exists', () => {
+    expect(existsSync(ipcDir)).toBe(false);
+    new IPC(ipcDir);
+    expect(existsSync(ipcDir)).toBe(true);
+  });
+
+  it('writes and reads request files', () => {
+    const ipc = new IPC(ipcDir);
+    ipc.sendRequest('req-1', { action: 'run', args: ['hello'] });
+
+    const data = ipc.readRequest('req-1');
+    expect(data).toEqual({ action: 'run', args: ['hello'] });
+  });
+
+  it('writes and reads response files', () => {
+    const ipc = new IPC(ipcDir);
+    ipc.writeResponse('resp-1', { status: 'ok', result: 42 });
+
+    const data = ipc.readResponse('resp-1');
+    expect(data).toEqual({ status: 'ok', result: 42 });
+  });
+
+  it('returns null for missing response', () => {
+    const ipc = new IPC(ipcDir);
+    expect(ipc.readResponse('nonexistent')).toBeNull();
+  });
+
+  it('returns null for missing request', () => {
+    const ipc = new IPC(ipcDir);
+    expect(ipc.readRequest('nonexistent')).toBeNull();
+  });
+
+  it('round-trips complex JSON data', () => {
+    const ipc = new IPC(ipcDir);
+    const complex = {
+      nested: { deeply: { value: [1, 2, 3] } },
+      unicode: '日本語',
+      special: 'hello\nworld\ttab',
+    };
+    ipc.sendRequest('complex', complex);
+    expect(ipc.readRequest('complex')).toEqual(complex);
+  });
+});

--- a/tests/container/runner.test.ts
+++ b/tests/container/runner.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runInContainer, type ContainerConfig } from '../../src/container/runner.js';
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+
+vi.mock('node:child_process', () => {
+  return {
+    spawn: vi.fn(),
+  };
+});
+
+import { spawn } from 'node:child_process';
+
+function mockProcess(stdout = '', stderr = '', exitCode = 0): ChildProcess {
+  const proc = new EventEmitter() as ChildProcess;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  (proc as any).stdout = stdoutEmitter;
+  (proc as any).stderr = stderrEmitter;
+
+  // Schedule data emission and close
+  setTimeout(() => {
+    if (stdout) stdoutEmitter.emit('data', Buffer.from(stdout));
+    if (stderr) stderrEmitter.emit('data', Buffer.from(stderr));
+    proc.emit('close', exitCode);
+  }, 0);
+
+  return proc;
+}
+
+describe('runInContainer', () => {
+  const baseConfig: ContainerConfig = {
+    runtime: 'docker',
+    image: 'test-image:latest',
+    mountPaths: [],
+  };
+
+  beforeEach(() => {
+    vi.mocked(spawn).mockReset();
+  });
+
+  it('spawns docker with correct args', async () => {
+    vi.mocked(spawn).mockReturnValue(mockProcess('hello'));
+    const result = await runInContainer(baseConfig, ['echo', 'hello']);
+
+    expect(spawn).toHaveBeenCalledWith(
+      'docker',
+      ['run', '--rm', '--network', 'none', 'test-image:latest', 'echo', 'hello'],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    expect(result.stdout).toBe('hello');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('spawns apple-container with container binary', async () => {
+    vi.mocked(spawn).mockReturnValue(mockProcess());
+    await runInContainer({ ...baseConfig, runtime: 'apple-container' }, ['ls']);
+
+    expect(spawn).toHaveBeenCalledWith(
+      'container',
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
+  it('handles read-only and writable mounts', async () => {
+    vi.mocked(spawn).mockReturnValue(mockProcess());
+    await runInContainer(
+      { ...baseConfig, mountPaths: ['/data'], writablePaths: ['/output'] },
+      ['run'],
+    );
+
+    const args = vi.mocked(spawn).mock.calls[0][1];
+    expect(args).toContain('-v');
+    expect(args).toContain('/data:/data:ro');
+    expect(args).toContain('/output:/output:rw');
+  });
+
+  it('passes environment variables', async () => {
+    vi.mocked(spawn).mockReturnValue(mockProcess());
+    await runInContainer(
+      { ...baseConfig, env: { FOO: 'bar', BAZ: 'qux' } },
+      ['test'],
+    );
+
+    const args = vi.mocked(spawn).mock.calls[0][1];
+    expect(args).toContain('-e');
+    expect(args).toContain('FOO=bar');
+    expect(args).toContain('BAZ=qux');
+  });
+
+  it('returns stdout, stderr, exitCode', async () => {
+    vi.mocked(spawn).mockReturnValue(mockProcess('out', 'err', 1));
+    const result = await runInContainer(baseConfig, ['fail']);
+    expect(result).toEqual({ stdout: 'out', stderr: 'err', exitCode: 1 });
+  });
+
+  it('rejects on spawn error', async () => {
+    const proc = new EventEmitter() as ChildProcess;
+    (proc as any).stdout = new EventEmitter();
+    (proc as any).stderr = new EventEmitter();
+    vi.mocked(spawn).mockReturnValue(proc);
+
+    const promise = runInContainer(baseConfig, ['bad']);
+    setTimeout(() => proc.emit('error', new Error('spawn ENOENT')), 0);
+
+    await expect(promise).rejects.toThrow('spawn ENOENT');
+  });
+
+  it('enables network when networkEnabled is true', async () => {
+    vi.mocked(spawn).mockReturnValue(mockProcess());
+    await runInContainer({ ...baseConfig, networkEnabled: true }, ['test']);
+
+    const args = vi.mocked(spawn).mock.calls[0][1];
+    expect(args).not.toContain('--network');
+  });
+});

--- a/tests/e2e/ingest-pipeline.test.ts
+++ b/tests/e2e/ingest-pipeline.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync, existsSync } from 'node:fs';
+import { Store } from '../../src/store/db.js';
+import { Engine } from '../../src/ecs/engine.js';
+import { IngestPipeline } from '../../src/ingest/pipeline.js';
+import { mockLogger, mockProvider, collectEvents } from '../helpers.js';
+
+describe('Ingest Pipeline E2E', () => {
+  let store: Store;
+  let engine: Engine;
+  let pipeline: IngestPipeline;
+  let uploadDir: string;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+    const logger = mockLogger();
+    const provider = mockProvider([]);
+    engine = new Engine(store, provider, logger);
+    uploadDir = join(tmpdir(), `chippr-e2e-ingest-${Date.now()}`);
+    pipeline = new IngestPipeline(engine, logger as any, uploadDir);
+  });
+
+  afterEach(() => {
+    store.close();
+    if (existsSync(uploadDir)) {
+      rmSync(uploadDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ingests a text file and creates entity with components', async () => {
+    const events = collectEvents(engine);
+
+    const result = await pipeline.ingest({
+      filename: 'test.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('Hello, world!'),
+      source: 'test',
+    });
+
+    expect(result.mediaId).toBeDefined();
+    expect(result.entityId).toBeDefined();
+    expect(result.category).toBe('text');
+    expect(result.extractedText).toContain('Hello, world!');
+
+    // Verify entity exists
+    expect(engine.entityExists(result.entityId)).toBe(true);
+
+    // Verify events were emitted
+    expect(events.some((e) => e.type === 'media:ingested')).toBe(true);
+  });
+
+  it('stores memory record for ingested file', async () => {
+    const result = await pipeline.ingest({
+      filename: 'doc.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('Important document content'),
+      source: 'test',
+      contextId: 'ctx-1',
+    });
+
+    // Memory should be stored with context
+    const memory = store.getMemory('ctx-1');
+    expect(memory.length).toBeGreaterThan(0);
+  });
+
+  it('batch upload creates multiple entities', async () => {
+    const results = await pipeline.ingestBatch([
+      {
+        filename: 'file1.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('File 1 content'),
+        source: 'test',
+      },
+      {
+        filename: 'file2.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('File 2 content'),
+        source: 'test',
+      },
+    ]);
+
+    expect(results.length).toBe(2);
+    expect(engine.entityExists(results[0].entityId)).toBe(true);
+    expect(engine.entityExists(results[1].entityId)).toBe(true);
+
+    // Verify they're different entities
+    expect(results[0].entityId).not.toBe(results[1].entityId);
+  });
+
+  it('emits entity:needs-routing when message is included', async () => {
+    const events = collectEvents(engine, 'entity:needs-routing');
+
+    await pipeline.ingest({
+      filename: 'test.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('content'),
+      source: 'test',
+      message: 'Analyze this file',
+    });
+
+    expect(events.some((e) => e.type === 'entity:needs-routing')).toBe(true);
+  });
+});

--- a/tests/e2e/objective-pipeline.test.ts
+++ b/tests/e2e/objective-pipeline.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Store } from '../../src/store/db.js';
+import { Engine } from '../../src/ecs/engine.js';
+import { mockLogger, collectEvents } from '../helpers.js';
+import createSystemSelector from '../../src/systems/system-selector.js';
+import createTaskGenerator from '../../src/systems/task-generator.js';
+import createJudge from '../../src/systems/judge.js';
+import createEntityCreationSystem from '../../src/systems/entity-creation.js';
+import type { ModelProvider, ModelResponse, ModelMessage, ToolDefinition } from '../../src/model/types.js';
+import { uniqueId } from '../../src/util/hash.js';
+
+/**
+ * E2E test: Objective → SystemSelector → TaskGenerator → subtasks → Judge
+ * Uses a scripted mock provider that responds differently based on the prompt content.
+ */
+describe('Objective Pipeline E2E', () => {
+  let store: Store;
+  let engine: Engine;
+
+  afterEach(() => {
+    store.close();
+  });
+
+  function createScriptedProvider(): ModelProvider {
+    return {
+      async generate(messages: ModelMessage[], tools?: ToolDefinition[]): Promise<ModelResponse> {
+        const lastMsg = messages[messages.length - 1].content;
+
+        // SystemSelector: select TaskGenerator via tool call
+        if (tools?.length && lastMsg.includes('Select the best system')) {
+          return {
+            content: '',
+            toolCalls: [{ id: 'tc-1', name: 'TaskGenerator', input: { entityId: 'e1' } }],
+          };
+        }
+
+        // TaskGenerator: generate subtasks
+        if (lastMsg && !lastMsg.includes('evaluator')) {
+          return {
+            content: JSON.stringify([
+              { task: 'Step 1: Research', taskId: 'step-1' },
+              { task: 'Step 2: Implement', taskId: 'step-2' },
+            ]),
+          };
+        }
+
+        // Judge: evaluate task
+        return {
+          content: JSON.stringify({
+            complete: true,
+            reasoning: 'Task completed successfully',
+            score: 0.85,
+          }),
+        };
+      },
+    };
+  }
+
+  it('routes objective through task generation pipeline', async () => {
+    store = new Store(':memory:');
+    const logger = mockLogger();
+    const provider = createScriptedProvider();
+    engine = new Engine(store, provider, logger);
+
+    // Register all systems
+    await engine.registerSystem(createEntityCreationSystem(engine));
+    await engine.registerSystem(createSystemSelector(engine));
+    await engine.registerSystem(createTaskGenerator(engine));
+    await engine.registerSystem(createJudge(engine));
+
+    const allEvents = collectEvents(engine);
+
+    // Submit an objective
+    const entityId = 'obj-1';
+    engine.createEntity(entityId);
+    engine.addComponent(entityId, 'ObjectiveDescription', { objective: 'Build a widget' });
+    engine.addComponent(entityId, 'TaskDescription', { task: 'Build a widget', complete: false });
+
+    engine.emit({
+      type: 'entity:needs-routing',
+      entityId,
+      data: { objective: 'Build a widget' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    // Wait for async event processing
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Verify SystemSelector ran and selected TaskGenerator
+    expect(engine.getComponent(entityId, 'SystemSelection')).toEqual({
+      selectedSystem: 'TaskGenerator',
+    });
+
+    // Verify subtask entities were created
+    expect(engine.entityExists('step-1')).toBe(true);
+    expect(engine.entityExists('step-2')).toBe(true);
+
+    // Verify subtask components
+    expect(engine.getComponent('step-1', 'TaskDescription')).toEqual({
+      task: 'Step 1: Research',
+      complete: false,
+    });
+    expect(engine.getComponent('step-1', 'TaskParent')).toEqual({ parentId: entityId });
+  });
+
+  it('persists all entities and events in the database', async () => {
+    store = new Store(':memory:');
+    const logger = mockLogger();
+    const provider = createScriptedProvider();
+    engine = new Engine(store, provider, logger);
+
+    await engine.registerSystem(createSystemSelector(engine));
+    await engine.registerSystem(createTaskGenerator(engine));
+
+    const entityId = 'persist-test';
+    engine.createEntity(entityId);
+    engine.addComponent(entityId, 'TaskDescription', { task: 'Persist test', complete: false });
+
+    engine.emit({
+      type: 'entity:needs-routing',
+      entityId,
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Verify database persistence
+    expect(store.entityExists(entityId)).toBe(true);
+    expect(store.entityExists('step-1')).toBe(true);
+
+    // Verify events were logged
+    const events = store.getEvents({ limit: 50 });
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.some((e: any) => e.type === 'entity:needs-routing')).toBe(true);
+    expect(events.some((e: any) => e.type === 'system:selected')).toBe(true);
+  });
+
+  it('handles judge evaluation of completed tasks', async () => {
+    store = new Store(':memory:');
+    const logger = mockLogger();
+    const provider: ModelProvider = {
+      async generate(): Promise<ModelResponse> {
+        return {
+          content: JSON.stringify({ complete: true, reasoning: 'Done', score: 0.9 }),
+        };
+      },
+    };
+    engine = new Engine(store, provider, logger);
+
+    await engine.registerSystem(createJudge(engine));
+
+    engine.createEntity('judged-task');
+    engine.addComponent('judged-task', 'TaskDescription', { task: 'A completed task', complete: false });
+
+    const judgedEvents = collectEvents(engine, 'task:judged');
+
+    engine.emit({
+      type: 'task:completed',
+      entityId: 'judged-task',
+      data: { result: 'Task result' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(judgedEvents.length).toBe(1);
+    expect(judgedEvents[0].data).toEqual({ complete: true, reasoning: 'Done', score: 0.9 });
+    expect(engine.getComponent('judged-task', 'Judgement')).toEqual({
+      complete: true,
+      reasoning: 'Done',
+      score: 0.9,
+    });
+  });
+
+  it('emits system:error when LLM returns invalid JSON in task generator', async () => {
+    store = new Store(':memory:');
+    const logger = mockLogger();
+    let callCount = 0;
+    const provider: ModelProvider = {
+      async generate(_messages: ModelMessage[], tools?: ToolDefinition[]): Promise<ModelResponse> {
+        callCount++;
+        if (tools?.length) {
+          return {
+            content: '',
+            toolCalls: [{ id: 'tc-1', name: 'TaskGenerator', input: { entityId: 'e1' } }],
+          };
+        }
+        return { content: 'not valid json {{' };
+      },
+    };
+    engine = new Engine(store, provider, logger);
+
+    await engine.registerSystem(createSystemSelector(engine));
+    await engine.registerSystem(createTaskGenerator(engine));
+
+    const errorEvents = collectEvents(engine, 'system:error');
+
+    engine.createEntity('bad-json');
+    engine.addComponent('bad-json', 'TaskDescription', { task: 'Test', complete: false });
+
+    engine.emit({
+      type: 'entity:needs-routing',
+      entityId: 'bad-json',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(errorEvents.some((e) => e.data.system === 'TaskGenerator')).toBe(true);
+  });
+});

--- a/tests/e2e/web-objective.test.ts
+++ b/tests/e2e/web-objective.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { request } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync, existsSync } from 'node:fs';
+import { Store } from '../../src/store/db.js';
+import { Engine } from '../../src/ecs/engine.js';
+import { IngestPipeline } from '../../src/ingest/pipeline.js';
+import { startWebServer } from '../../src/web/server.js';
+import { mockLogger, mockProvider, collectEvents } from '../helpers.js';
+import type { Server } from 'node:http';
+
+function httpPost(
+  port: number,
+  path: string,
+  body: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        method: 'POST',
+        path,
+        headers: { 'Content-Type': 'application/json', ...headers },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode!,
+            body: Buffer.concat(chunks).toString(),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+describe('Web → Objective → SSE E2E', () => {
+  let store: Store;
+  let engine: Engine;
+  let server: Server;
+  let uploadDir: string;
+  let port: number;
+
+  beforeEach(async () => {
+    store = new Store(':memory:');
+    const logger = mockLogger();
+    const provider = mockProvider([]);
+    engine = new Engine(store, provider, logger);
+    uploadDir = join(tmpdir(), `chippr-e2e-web-${Date.now()}`);
+    const pipeline = new IngestPipeline(engine, logger as any, uploadDir);
+
+    server = startWebServer({ port: 0, engine, pipeline, logger: logger as any });
+    await new Promise<void>((resolve) => {
+      server.on('listening', () => {
+        port = (server.address() as { port: number }).port;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    store.close();
+    if (existsSync(uploadDir)) {
+      rmSync(uploadDir, { recursive: true, force: true });
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('POST /api/objective creates entity and emits events', async () => {
+    const events = collectEvents(engine);
+
+    const res = await httpPost(port, '/api/objective', JSON.stringify({
+      objective: 'E2E test objective',
+    }));
+
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.entityId).toBeDefined();
+
+    // Verify entity was created with correct components
+    expect(engine.entityExists(data.entityId)).toBe(true);
+    expect(engine.getComponent(data.entityId, 'ObjectiveDescription')).toEqual({
+      objective: 'E2E test objective',
+    });
+    expect(engine.getComponent(data.entityId, 'TaskDescription')).toEqual({
+      task: 'E2E test objective',
+      complete: false,
+    });
+
+    // Verify event was emitted
+    expect(events.some((e) => e.type === 'entity:needs-routing' && e.entityId === data.entityId)).toBe(true);
+  });
+
+  it('SSE client receives events', async () => {
+    const receivedData: string[] = [];
+
+    // Connect SSE client
+    await new Promise<void>((resolve, reject) => {
+      const req = request(
+        { hostname: '127.0.0.1', port, method: 'GET', path: '/api/events' },
+        (res) => {
+          res.on('data', (chunk) => {
+            receivedData.push(chunk.toString());
+          });
+
+          // Once SSE connection is established, submit an objective
+          setTimeout(async () => {
+            await httpPost(port, '/api/objective', JSON.stringify({
+              objective: 'SSE test',
+            }));
+
+            // Give time for event to propagate
+            setTimeout(() => {
+              res.destroy();
+              resolve();
+            }, 100);
+          }, 50);
+        },
+      );
+      req.on('error', (err) => {
+        // Ignore connection reset errors from destroying the response
+        if ((err as any).code !== 'ECONNRESET') reject(err);
+      });
+      req.end();
+    });
+
+    // Verify we received SSE data containing the event
+    const allData = receivedData.join('');
+    expect(allData).toContain('entity:needs-routing');
+  });
+
+  it('SSE client cleanup on disconnect', async () => {
+    // Connect and immediately disconnect
+    await new Promise<void>((resolve) => {
+      const req = request(
+        { hostname: '127.0.0.1', port, method: 'GET', path: '/api/events' },
+        (res) => {
+          res.destroy();
+          setTimeout(resolve, 50);
+        },
+      );
+      req.on('error', () => {}); // Ignore errors
+      req.end();
+    });
+
+    // After disconnect, submitting an objective should still work
+    const res = await httpPost(port, '/api/objective', JSON.stringify({
+      objective: 'After disconnect',
+    }));
+    expect(res.status).toBe(200);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,70 @@
+import { vi } from 'vitest';
+import { Store } from '../src/store/db.js';
+import { Engine } from '../src/ecs/engine.js';
+import type { ModelProvider, ModelResponse } from '../src/model/types.js';
+import type { Logger } from '../src/util/logger.js';
+import type { ECSEvent } from '../src/ecs/types.js';
+
+export function mockLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+    level: 'info',
+  } as unknown as Logger;
+}
+
+export function mockProvider(responses: string[]): ModelProvider {
+  let callIndex = 0;
+  return {
+    async generate(): Promise<ModelResponse> {
+      const content = responses[callIndex] ?? '{}';
+      callIndex++;
+      return { content };
+    },
+  };
+}
+
+export function mockProviderWithTools(responses: ModelResponse[]): ModelProvider {
+  let callIndex = 0;
+  return {
+    async generate(): Promise<ModelResponse> {
+      const response = responses[callIndex] ?? { content: '' };
+      callIndex++;
+      return response;
+    },
+  };
+}
+
+export function createTestEngine(opts?: {
+  provider?: ModelProvider;
+  logger?: Logger;
+}): { engine: Engine; store: Store; logger: Logger; provider: ModelProvider } {
+  const store = new Store(':memory:');
+  const logger = opts?.logger ?? mockLogger();
+  const provider = opts?.provider ?? mockProvider([]);
+  const engine = new Engine(store, provider, logger);
+  return { engine, store, logger, provider };
+}
+
+export function makeEvent(overrides: Partial<ECSEvent> = {}): ECSEvent {
+  return {
+    type: 'test:event',
+    entityId: 'test-entity',
+    data: {},
+    source: 'test',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+/** Collect events emitted by the engine for assertions. */
+export function collectEvents(engine: Engine, eventType = '*'): ECSEvent[] {
+  const events: ECSEvent[] = [];
+  engine.on(eventType, (e) => events.push(e));
+  return events;
+}

--- a/tests/model/claude.test.ts
+++ b/tests/model/claude.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ClaudeProvider } from '../../src/model/claude.js';
+
+describe('ClaudeProvider', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetch(body: unknown, status = 200) {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    });
+  }
+
+  it('sends correct headers', async () => {
+    mockFetch({ content: [{ type: 'text', text: 'hi' }] });
+    const provider = new ClaudeProvider('test-model', { apiKey: 'sk-test' });
+    await provider.generate([{ role: 'user', content: 'hello' }]);
+
+    const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const headers = call[1].headers;
+    expect(headers['x-api-key']).toBe('sk-test');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('builds correct request body with system message', async () => {
+    mockFetch({ content: [{ type: 'text', text: 'ok' }] });
+    const provider = new ClaudeProvider('claude-test');
+    await provider.generate([
+      { role: 'system', content: 'Be helpful' },
+      { role: 'user', content: 'hello' },
+    ]);
+
+    const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.model).toBe('claude-test');
+    expect(body.system).toBe('Be helpful');
+    expect(body.messages).toEqual([{ role: 'user', content: 'hello' }]);
+    expect(body.max_tokens).toBe(4096);
+  });
+
+  it('includes tools in request when provided', async () => {
+    mockFetch({ content: [{ type: 'text', text: '' }] });
+    const provider = new ClaudeProvider('test-model', { apiKey: 'sk-test' });
+    await provider.generate(
+      [{ role: 'user', content: 'test' }],
+      [{ name: 'myTool', description: 'does stuff', inputSchema: { type: 'object' } }],
+    );
+
+    const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.tools).toEqual([
+      { name: 'myTool', description: 'does stuff', input_schema: { type: 'object' } },
+    ]);
+  });
+
+  it('parses text content blocks', async () => {
+    mockFetch({
+      content: [
+        { type: 'text', text: 'Hello ' },
+        { type: 'text', text: 'world' },
+      ],
+    });
+    const provider = new ClaudeProvider('test-model', { apiKey: 'sk-test' });
+    const response = await provider.generate([{ role: 'user', content: 'hi' }]);
+    expect(response.content).toBe('Hello world');
+  });
+
+  it('parses tool_use content blocks into toolCalls', async () => {
+    mockFetch({
+      content: [
+        {
+          type: 'tool_use',
+          id: 'call-1',
+          name: 'myTool',
+          input: { key: 'value' },
+        },
+      ],
+    });
+    const provider = new ClaudeProvider('test-model', { apiKey: 'sk-test' });
+    const response = await provider.generate([{ role: 'user', content: 'test' }]);
+    expect(response.toolCalls).toEqual([
+      { id: 'call-1', name: 'myTool', input: { key: 'value' } },
+    ]);
+  });
+
+  it('parses usage data', async () => {
+    mockFetch({
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+    const provider = new ClaudeProvider('test-model', { apiKey: 'sk-test' });
+    const response = await provider.generate([{ role: 'user', content: 'test' }]);
+    expect(response.usage).toEqual({ inputTokens: 10, outputTokens: 20 });
+  });
+
+  it('throws on non-OK response', async () => {
+    mockFetch({ error: 'bad request' }, 400);
+    const provider = new ClaudeProvider('test-model', { apiKey: 'sk-test' });
+    await expect(provider.generate([{ role: 'user', content: 'hi' }])).rejects.toThrow(
+      'Claude API error 400',
+    );
+  });
+
+  describe('agentLoop', () => {
+    it('yields text and done events when no tool calls', async () => {
+      mockFetch({ content: [{ type: 'text', text: 'result' }] });
+      const provider = new ClaudeProvider('test-model', { apiKey: 'sk-test' });
+
+      const events = [];
+      for await (const event of provider.agentLoop('test prompt', [], vi.fn())) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([
+        { type: 'text', data: 'result' },
+        { type: 'done', data: 'result' },
+      ]);
+    });
+
+    it('executes tools and yields tool events', async () => {
+      let callCount = 0;
+      globalThis.fetch = vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              content: [
+                { type: 'tool_use', id: 'c1', name: 'myTool', input: { x: 1 } },
+              ],
+            }),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            content: [{ type: 'text', text: 'final' }],
+          }),
+        };
+      });
+
+      const executor = vi.fn().mockResolvedValue({ toolCallId: 'c1', content: 'tool-result' });
+      const provider = new ClaudeProvider('test-model', { apiKey: 'sk-test' });
+
+      const events = [];
+      for await (const event of provider.agentLoop('test', [{ name: 'myTool', description: 'test', inputSchema: {} }], executor)) {
+        events.push(event);
+      }
+
+      expect(events.map((e) => e.type)).toEqual([
+        'tool_call', 'tool_result', 'text', 'done',
+      ]);
+      expect(executor).toHaveBeenCalledWith({ id: 'c1', name: 'myTool', input: { x: 1 } });
+    });
+  });
+});

--- a/tests/model/local.test.ts
+++ b/tests/model/local.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { LocalProvider } from '../../src/model/local.js';
+
+describe('LocalProvider', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetch(body: unknown, status = 200) {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    });
+  }
+
+  it('sends correct request body', async () => {
+    mockFetch({ choices: [{ message: { content: 'hi' } }] });
+    const provider = new LocalProvider('http://localhost:1234/v1', 'test-model');
+    await provider.generate([{ role: 'user', content: 'hello' }]);
+
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('http://localhost:1234/v1/chat/completions');
+    const body = JSON.parse(opts.body);
+    expect(body.model).toBe('test-model');
+    expect(body.messages).toEqual([{ role: 'user', content: 'hello' }]);
+  });
+
+  it('includes tools in OpenAI format', async () => {
+    mockFetch({ choices: [{ message: { content: '' } }] });
+    const provider = new LocalProvider();
+    await provider.generate(
+      [{ role: 'user', content: 'test' }],
+      [{ name: 'myTool', description: 'desc', inputSchema: { type: 'object' } }],
+    );
+
+    const body = JSON.parse((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.tools).toEqual([
+      {
+        type: 'function',
+        function: { name: 'myTool', description: 'desc', parameters: { type: 'object' } },
+      },
+    ]);
+  });
+
+  it('parses choices[0] response', async () => {
+    mockFetch({
+      choices: [{ message: { content: 'result text' } }],
+      usage: { prompt_tokens: 5, completion_tokens: 10 },
+    });
+    const provider = new LocalProvider();
+    const response = await provider.generate([{ role: 'user', content: 'test' }]);
+    expect(response.content).toBe('result text');
+    expect(response.usage).toEqual({ inputTokens: 5, outputTokens: 10 });
+  });
+
+  it('returns empty content when no choices', async () => {
+    mockFetch({ choices: [] });
+    const provider = new LocalProvider();
+    const response = await provider.generate([{ role: 'user', content: 'test' }]);
+    expect(response.content).toBe('');
+    expect(response.toolCalls).toBeUndefined();
+  });
+
+  it('parses tool_calls from response', async () => {
+    mockFetch({
+      choices: [{
+        message: {
+          content: null,
+          tool_calls: [{
+            id: 'tc-1',
+            function: { name: 'myTool', arguments: '{"x":1}' },
+          }],
+        },
+      }],
+    });
+    const provider = new LocalProvider();
+    const response = await provider.generate([{ role: 'user', content: 'test' }]);
+    expect(response.toolCalls).toEqual([
+      { id: 'tc-1', name: 'myTool', input: { x: 1 } },
+    ]);
+  });
+
+  it('throws on non-OK response', async () => {
+    mockFetch({ error: 'not found' }, 404);
+    const provider = new LocalProvider();
+    await expect(provider.generate([{ role: 'user', content: 'hi' }])).rejects.toThrow(
+      'Local model API error 404',
+    );
+  });
+
+  describe('agentLoop', () => {
+    it('yields done when no tool calls', async () => {
+      mockFetch({ choices: [{ message: { content: 'answer' } }] });
+      const provider = new LocalProvider();
+
+      const events = [];
+      for await (const event of provider.agentLoop('prompt', [], vi.fn())) {
+        events.push(event);
+      }
+
+      expect(events.map((e) => e.type)).toEqual(['text', 'done']);
+    });
+  });
+});

--- a/tests/model/provider.test.ts
+++ b/tests/model/provider.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { createProvider } from '../../src/model/provider.js';
+import { ClaudeProvider } from '../../src/model/claude.js';
+import { LocalProvider } from '../../src/model/local.js';
+import type { Config } from '../../src/util/config.js';
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    MODEL_PROVIDER: 'claude',
+    CLAUDE_MODEL: 'sonnet',
+    LOCAL_URL: 'http://localhost:11434/v1',
+    LOCAL_MODEL: 'bitnet-b1.58',
+    DB_PATH: ':memory:',
+    CONTAINER_RUNTIME: 'docker',
+    CONTAINER_IMAGE: 'chippr-agent:latest',
+    LOG_LEVEL: 'info',
+    WEB_PORT: 3000,
+    WEB_ENABLED: 'true',
+    UPLOAD_DIR: './uploads',
+    GEMINI_EMBEDDING_MODEL: 'gemini-embedding-001',
+    ...overrides,
+  } as Config;
+}
+
+describe('createProvider', () => {
+  it('returns ClaudeProvider when MODEL_PROVIDER is claude', () => {
+    const provider = createProvider(makeConfig({ MODEL_PROVIDER: 'claude' }));
+    expect(provider).toBeInstanceOf(ClaudeProvider);
+  });
+
+  it('returns LocalProvider when MODEL_PROVIDER is local', () => {
+    const provider = createProvider(makeConfig({ MODEL_PROVIDER: 'local' }));
+    expect(provider).toBeInstanceOf(LocalProvider);
+  });
+
+  it('defaults to ClaudeProvider', () => {
+    const provider = createProvider(makeConfig());
+    expect(provider).toBeInstanceOf(ClaudeProvider);
+  });
+});

--- a/tests/store/migrations.test.ts
+++ b/tests/store/migrations.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../../src/store/migrations.js';
+
+describe('runMigrations', () => {
+  it('creates all tables on fresh database', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all()
+      .map((r: { name: string }) => r.name);
+
+    expect(tables).toContain('entities');
+    expect(tables).toContain('components');
+    expect(tables).toContain('events');
+    expect(tables).toContain('memory');
+    expect(tables).toContain('scheduled_tasks');
+    expect(tables).toContain('media');
+    expect(tables).toContain('schema_version');
+
+    db.close();
+  });
+
+  it('records version in schema_version table', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+
+    const versions = db
+      .prepare('SELECT version FROM schema_version ORDER BY version')
+      .all()
+      .map((r: { version: number }) => r.version);
+
+    expect(versions).toEqual([1, 2]);
+    db.close();
+  });
+
+  it('skips already-applied migrations', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    // Run again — should not throw
+    runMigrations(db);
+
+    const versions = db
+      .prepare('SELECT version FROM schema_version ORDER BY version')
+      .all()
+      .map((r: { version: number }) => r.version);
+
+    expect(versions).toEqual([1, 2]);
+    db.close();
+  });
+
+  it('sets WAL journal mode and foreign keys', () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+
+    const fk = db.pragma('foreign_keys') as Array<{ foreign_keys: number }>;
+    expect(fk[0].foreign_keys).toBe(1);
+    db.close();
+  });
+});

--- a/tests/systems/entity-creation.test.ts
+++ b/tests/systems/entity-creation.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTestEngine, collectEvents, makeEvent } from '../helpers.js';
+import createEntityCreationSystem from '../../src/systems/entity-creation.js';
+import type { Engine } from '../../src/ecs/engine.js';
+import type { Store } from '../../src/store/db.js';
+
+describe('EntityCreationSystem', () => {
+  let engine: Engine;
+  let store: Store;
+
+  beforeEach(async () => {
+    ({ engine, store } = createTestEngine());
+    const system = createEntityCreationSystem(engine);
+    await engine.registerSystem(system);
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('creates entity on entity:create event', () => {
+    engine.emit(makeEvent({
+      type: 'entity:create',
+      entityId: 'new-entity',
+      data: {},
+    }));
+
+    expect(engine.entityExists('new-entity')).toBe(true);
+  });
+
+  it('attaches components from event data', () => {
+    engine.emit(makeEvent({
+      type: 'entity:create',
+      entityId: 'with-comps',
+      data: {
+        components: {
+          Health: { value: 100 },
+          Name: { name: 'TestEntity' },
+        },
+      },
+    }));
+
+    expect(engine.getComponent('with-comps', 'Health')).toEqual({ value: 100 });
+    expect(engine.getComponent('with-comps', 'Name')).toEqual({ name: 'TestEntity' });
+  });
+
+  it('skips creation if entity already exists (idempotent)', () => {
+    engine.createEntity('existing');
+    engine.addComponent('existing', 'Foo', { bar: 1 });
+
+    engine.emit(makeEvent({
+      type: 'entity:create',
+      entityId: 'existing',
+      data: { components: { Baz: { x: 2 } } },
+    }));
+
+    // Original component should still be there
+    expect(engine.getComponent('existing', 'Foo')).toEqual({ bar: 1 });
+    // New component should be added
+    expect(engine.getComponent('existing', 'Baz')).toEqual({ x: 2 });
+  });
+
+  it('emits entity:created after processing', () => {
+    const events = collectEvents(engine, 'entity:created');
+
+    engine.emit(makeEvent({
+      type: 'entity:create',
+      entityId: 'test-emit',
+      data: {},
+    }));
+
+    expect(events.some((e) => e.type === 'entity:created' && e.entityId === 'test-emit')).toBe(true);
+  });
+
+  it('handles events with no components gracefully', () => {
+    engine.emit(makeEvent({
+      type: 'entity:create',
+      entityId: 'no-comps',
+      data: {},
+    }));
+
+    expect(engine.entityExists('no-comps')).toBe(true);
+  });
+});

--- a/tests/systems/judge.test.ts
+++ b/tests/systems/judge.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createTestEngine, collectEvents, mockProvider, mockLogger } from '../helpers.js';
+import createJudge from '../../src/systems/judge.js';
+import type { Engine } from '../../src/ecs/engine.js';
+import type { Store } from '../../src/store/db.js';
+
+describe('TheJudge', () => {
+  let engine: Engine;
+  let store: Store;
+
+  function setup(llmResponse: string) {
+    const result = createTestEngine({
+      provider: mockProvider([llmResponse]),
+      logger: mockLogger(),
+    });
+    engine = result.engine;
+    store = result.store;
+  }
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('parses judgement from LLM response and adds component', async () => {
+    setup(JSON.stringify({ complete: true, reasoning: 'Task done', score: 0.9 }));
+
+    const system = createJudge(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('task-1');
+    engine.addComponent('task-1', 'TaskDescription', { task: 'Do something', complete: false });
+
+    await system.handleEvent({
+      type: 'task:completed',
+      entityId: 'task-1',
+      data: { result: 'It was done' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    const judgement = engine.getComponent('task-1', 'Judgement');
+    expect(judgement).toEqual({ complete: true, reasoning: 'Task done', score: 0.9 });
+  });
+
+  it('sets TaskDescription.complete when judge says complete', async () => {
+    setup(JSON.stringify({ complete: true, reasoning: 'Done', score: 1.0 }));
+
+    const system = createJudge(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('task-2');
+    engine.addComponent('task-2', 'TaskDescription', { task: 'Test', complete: false });
+
+    await system.handleEvent({
+      type: 'task:completed',
+      entityId: 'task-2',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    const desc = engine.getComponent('task-2', 'TaskDescription');
+    expect(desc?.complete).toBe(true);
+  });
+
+  it('emits task:judged event', async () => {
+    setup(JSON.stringify({ complete: false, reasoning: 'Not done', score: 0.3 }));
+
+    const system = createJudge(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('task-3');
+    engine.addComponent('task-3', 'TaskDescription', { task: 'Test', complete: false });
+
+    const events = collectEvents(engine, 'task:judged');
+
+    await system.handleEvent({
+      type: 'task:completed',
+      entityId: 'task-3',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(events.some((e) => e.type === 'task:judged' && e.entityId === 'task-3')).toBe(true);
+  });
+
+  it('emits system:error on parse failure', async () => {
+    setup('not json at all');
+
+    const system = createJudge(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('task-4');
+    engine.addComponent('task-4', 'TaskDescription', { task: 'Test', complete: false });
+
+    const events = collectEvents(engine, 'system:error');
+
+    await system.handleEvent({
+      type: 'task:completed',
+      entityId: 'task-4',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(events.some((e) => e.type === 'system:error' && e.data.system === 'TheJudge')).toBe(true);
+  });
+
+  it('ignores events without TaskDescription', async () => {
+    setup('{}');
+
+    const system = createJudge(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('no-desc');
+
+    await system.handleEvent({
+      type: 'task:completed',
+      entityId: 'no-desc',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    // Should not throw, no judgement added
+    expect(engine.getComponent('no-desc', 'Judgement')).toBeNull();
+  });
+
+  it('does not set complete when judge says not complete', async () => {
+    setup(JSON.stringify({ complete: false, reasoning: 'Needs work', score: 0.2 }));
+
+    const system = createJudge(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('task-5');
+    engine.addComponent('task-5', 'TaskDescription', { task: 'Test', complete: false });
+
+    await system.handleEvent({
+      type: 'task:completed',
+      entityId: 'task-5',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    const desc = engine.getComponent('task-5', 'TaskDescription');
+    expect(desc?.complete).toBe(false);
+  });
+});

--- a/tests/systems/loader.test.ts
+++ b/tests/systems/loader.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createTestEngine } from '../helpers.js';
+import { loadSystems } from '../../src/systems/loader.js';
+import type { Engine } from '../../src/ecs/engine.js';
+import type { Store } from '../../src/store/db.js';
+
+describe('loadSystems', () => {
+  let engine: Engine;
+  let store: Store;
+  let systemsDir: string;
+
+  beforeEach(() => {
+    ({ engine, store } = createTestEngine());
+    systemsDir = join(tmpdir(), `chippr-test-systems-${Date.now()}`);
+    mkdirSync(systemsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(systemsDir, { recursive: true, force: true });
+  });
+
+  it('loads and registers system files from directory', async () => {
+    writeFileSync(
+      join(systemsDir, 'test-system.js'),
+      `export default function(engine) {
+        return {
+          name: 'TestSystem',
+          version: '1.0.0',
+          type: 'system',
+          description: 'A test system',
+          init() {},
+          async handleEvent() {},
+        };
+      }`,
+    );
+
+    await loadSystems(engine, systemsDir);
+    expect(engine.getSystem('TestSystem')).toBeDefined();
+  });
+
+  it('skips loader.ts itself', async () => {
+    writeFileSync(join(systemsDir, 'loader.ts'), 'export default function() {}');
+    writeFileSync(join(systemsDir, 'loader.js'), 'export default function() {}');
+
+    // Should not throw and should not register anything
+    await loadSystems(engine, systemsDir);
+    expect(engine.getSystems().size).toBe(0);
+  });
+
+  it('handles modules without default export', async () => {
+    writeFileSync(
+      join(systemsDir, 'no-default.js'),
+      `export const foo = 'bar';`,
+    );
+
+    // Should not throw
+    await loadSystems(engine, systemsDir);
+    expect(engine.getSystems().size).toBe(0);
+  });
+
+  it('handles empty directory', async () => {
+    await loadSystems(engine, systemsDir);
+    expect(engine.getSystems().size).toBe(0);
+  });
+});

--- a/tests/systems/system-selector.test.ts
+++ b/tests/systems/system-selector.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { createTestEngine, collectEvents, mockProviderWithTools, mockLogger } from '../helpers.js';
+import createSystemSelector from '../../src/systems/system-selector.js';
+import type { Engine } from '../../src/ecs/engine.js';
+import type { Store } from '../../src/store/db.js';
+import type { ModelResponse } from '../../src/model/types.js';
+
+describe('SystemSelector', () => {
+  let engine: Engine;
+  let store: Store;
+
+  function setup(responses: ModelResponse[]) {
+    const result = createTestEngine({
+      provider: mockProviderWithTools(responses),
+      logger: mockLogger(),
+    });
+    engine = result.engine;
+    store = result.store;
+  }
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('emits system:selected on tool call response', async () => {
+    setup([{
+      content: '',
+      toolCalls: [{ id: 'c1', name: 'TaskGenerator', input: { entityId: 'e1' } }],
+    }]);
+
+    const system = createSystemSelector(engine);
+    await engine.registerSystem(system);
+
+    // Register a non-core system so there are tools to select from
+    await engine.registerSystem({
+      name: 'TaskGenerator',
+      version: '1.0.0',
+      type: 'system',
+      description: 'Generates tasks',
+      init() {},
+      async handleEvent() {},
+    });
+
+    engine.createEntity('e1');
+    engine.addComponent('e1', 'TaskDescription', { task: 'Test task', complete: false });
+
+    const events = collectEvents(engine, 'system:selected');
+
+    await system.handleEvent({
+      type: 'entity:needs-routing',
+      entityId: 'e1',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(events.some((e) => e.type === 'system:selected' && e.data.system === 'TaskGenerator')).toBe(true);
+  });
+
+  it('adds SystemSelection component', async () => {
+    setup([{
+      content: '',
+      toolCalls: [{ id: 'c1', name: 'TestSystem', input: { entityId: 'e1' } }],
+    }]);
+
+    const system = createSystemSelector(engine);
+    await engine.registerSystem(system);
+
+    await engine.registerSystem({
+      name: 'TestSystem',
+      version: '1.0.0',
+      type: 'system',
+      description: 'A test system',
+      init() {},
+      async handleEvent() {},
+    });
+
+    engine.createEntity('e1');
+    engine.addComponent('e1', 'TaskDescription', { task: 'Test', complete: false });
+
+    await system.handleEvent({
+      type: 'entity:needs-routing',
+      entityId: 'e1',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(engine.getComponent('e1', 'SystemSelection')).toEqual({ selectedSystem: 'TestSystem' });
+  });
+
+  it('returns silently when no non-core systems registered', async () => {
+    setup([{ content: '' }]);
+
+    const system = createSystemSelector(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('e1');
+    engine.addComponent('e1', 'TaskDescription', { task: 'Test', complete: false });
+
+    // Should not throw
+    await system.handleEvent({
+      type: 'entity:needs-routing',
+      entityId: 'e1',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+  });
+
+  it('emits system:error when no toolCalls returned', async () => {
+    setup([{ content: 'I cannot select a system' }]);
+
+    const system = createSystemSelector(engine);
+    await engine.registerSystem(system);
+
+    await engine.registerSystem({
+      name: 'SomeSystem',
+      version: '1.0.0',
+      type: 'system',
+      description: 'A system',
+      init() {},
+      async handleEvent() {},
+    });
+
+    engine.createEntity('e1');
+    engine.addComponent('e1', 'TaskDescription', { task: 'Test', complete: false });
+
+    const events = collectEvents(engine, 'system:error');
+
+    await system.handleEvent({
+      type: 'entity:needs-routing',
+      entityId: 'e1',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(events.some((e) => e.type === 'system:error' && e.data.system === 'SystemSelector')).toBe(true);
+  });
+
+  it('ignores events without TaskDescription', async () => {
+    setup([{ content: '' }]);
+
+    const system = createSystemSelector(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('e1');
+
+    await system.handleEvent({
+      type: 'entity:needs-routing',
+      entityId: 'e1',
+      data: {},
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(engine.getComponent('e1', 'SystemSelection')).toBeNull();
+  });
+});

--- a/tests/systems/task-generator.test.ts
+++ b/tests/systems/task-generator.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestEngine, collectEvents, mockProvider, mockLogger } from '../helpers.js';
+import createTaskGenerator from '../../src/systems/task-generator.js';
+import type { Engine } from '../../src/ecs/engine.js';
+import type { Store } from '../../src/store/db.js';
+
+describe('TaskGenerator', () => {
+  let engine: Engine;
+  let store: Store;
+
+  function setup(llmResponse: string) {
+    const result = createTestEngine({
+      provider: mockProvider([llmResponse]),
+      logger: mockLogger(),
+    });
+    engine = result.engine;
+    store = result.store;
+  }
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('generates subtask entities from LLM response', async () => {
+    setup(JSON.stringify([
+      { task: 'Subtask A', taskId: 'st-a' },
+      { task: 'Subtask B', taskId: 'st-b' },
+    ]));
+
+    const system = createTaskGenerator(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('obj-1');
+    engine.addComponent('obj-1', 'TaskDescription', { task: 'Build something', complete: false });
+
+    await system.handleEvent({
+      type: 'system:selected',
+      entityId: 'obj-1',
+      data: { system: 'TaskGenerator' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(engine.entityExists('st-a')).toBe(true);
+    expect(engine.entityExists('st-b')).toBe(true);
+  });
+
+  it('adds TaskDescription and TaskParent components', async () => {
+    setup(JSON.stringify([{ task: 'Do thing', taskId: 'child-1' }]));
+
+    const system = createTaskGenerator(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('parent');
+    engine.addComponent('parent', 'TaskDescription', { task: 'Parent task', complete: false });
+
+    await system.handleEvent({
+      type: 'system:selected',
+      entityId: 'parent',
+      data: { system: 'TaskGenerator' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(engine.getComponent('child-1', 'TaskDescription')).toEqual({ task: 'Do thing', complete: false });
+    expect(engine.getComponent('child-1', 'TaskParent')).toEqual({ parentId: 'parent' });
+  });
+
+  it('emits entity:needs-routing for each subtask', async () => {
+    setup(JSON.stringify([
+      { task: 'A', taskId: 'a' },
+      { task: 'B', taskId: 'b' },
+    ]));
+
+    const system = createTaskGenerator(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('parent');
+    engine.addComponent('parent', 'TaskDescription', { task: 'Test', complete: false });
+
+    const events = collectEvents(engine, 'entity:needs-routing');
+
+    await system.handleEvent({
+      type: 'system:selected',
+      entityId: 'parent',
+      data: { system: 'TaskGenerator' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    const routingEvents = events.filter((e) => e.type === 'entity:needs-routing');
+    expect(routingEvents.length).toBe(2);
+    expect(routingEvents.map((e) => e.entityId).sort()).toEqual(['a', 'b']);
+  });
+
+  it('emits system:error on JSON parse failure', async () => {
+    setup('not valid json');
+
+    const system = createTaskGenerator(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('e1');
+    engine.addComponent('e1', 'TaskDescription', { task: 'test', complete: false });
+
+    const events = collectEvents(engine, 'system:error');
+
+    await system.handleEvent({
+      type: 'system:selected',
+      entityId: 'e1',
+      data: { system: 'TaskGenerator' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    expect(events.some((e) => e.type === 'system:error' && e.data.system === 'TaskGenerator')).toBe(true);
+  });
+
+  it('ignores events without TaskDescription', async () => {
+    setup('[]');
+
+    const system = createTaskGenerator(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('empty');
+
+    // Should not throw
+    await system.handleEvent({
+      type: 'system:selected',
+      entityId: 'empty',
+      data: { system: 'TaskGenerator' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+  });
+
+  it('handles schema validation failures', async () => {
+    setup(JSON.stringify([{ invalid: 'schema' }]));
+
+    const system = createTaskGenerator(engine);
+    await engine.registerSystem(system);
+
+    engine.createEntity('e1');
+    engine.addComponent('e1', 'TaskDescription', { task: 'test', complete: false });
+
+    // Should not throw, just log warning
+    await system.handleEvent({
+      type: 'system:selected',
+      entityId: 'e1',
+      data: { system: 'TaskGenerator' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+  });
+});

--- a/tests/util/config.test.ts
+++ b/tests/util/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadConfig } from '../../src/util/config.js';
+
+describe('loadConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Clear all CHIPPR_ env vars
+    vi.stubEnv('CHIPPR_MODEL_PROVIDER', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_CLAUDE_MODEL', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_LOCAL_URL', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_LOCAL_MODEL', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_DB_PATH', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_CONTAINER_RUNTIME', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_CONTAINER_IMAGE', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_LOG_LEVEL', undefined as unknown as string);
+    vi.stubEnv('GEMINI_API_KEY', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_WEB_PORT', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_WEB_ENABLED', undefined as unknown as string);
+    vi.stubEnv('CHIPPR_UPLOAD_DIR', undefined as unknown as string);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns defaults when no env vars set', () => {
+    const config = loadConfig();
+    expect(config.MODEL_PROVIDER).toBe('claude');
+    expect(config.CLAUDE_MODEL).toBe('sonnet');
+    expect(config.LOCAL_URL).toBe('http://localhost:11434/v1');
+    expect(config.LOCAL_MODEL).toBe('bitnet-b1.58');
+    expect(config.DB_PATH).toBe('./chippr.db');
+    expect(config.CONTAINER_RUNTIME).toBe('docker');
+    expect(config.LOG_LEVEL).toBe('info');
+    expect(config.WEB_PORT).toBe(3000);
+    expect(config.WEB_ENABLED).toBe('true');
+    expect(config.UPLOAD_DIR).toBe('./uploads');
+  });
+
+  it('overrides defaults with env vars', () => {
+    vi.stubEnv('CHIPPR_MODEL_PROVIDER', 'local');
+    vi.stubEnv('CHIPPR_DB_PATH', '/tmp/test.db');
+    vi.stubEnv('CHIPPR_WEB_PORT', '8080');
+    const config = loadConfig();
+    expect(config.MODEL_PROVIDER).toBe('local');
+    expect(config.DB_PATH).toBe('/tmp/test.db');
+    expect(config.WEB_PORT).toBe(8080);
+  });
+
+  it('rejects invalid MODEL_PROVIDER', () => {
+    vi.stubEnv('CHIPPR_MODEL_PROVIDER', 'invalid');
+    expect(() => loadConfig()).toThrow();
+  });
+
+  it('coerces WEB_PORT to number', () => {
+    vi.stubEnv('CHIPPR_WEB_PORT', '9999');
+    const config = loadConfig();
+    expect(config.WEB_PORT).toBe(9999);
+    expect(typeof config.WEB_PORT).toBe('number');
+  });
+
+  it('handles optional GEMINI_API_KEY', () => {
+    const config = loadConfig();
+    expect(config.GEMINI_API_KEY).toBeUndefined();
+
+    vi.stubEnv('GEMINI_API_KEY', 'test-key');
+    const config2 = loadConfig();
+    expect(config2.GEMINI_API_KEY).toBe('test-key');
+  });
+
+  it('rejects invalid LOG_LEVEL', () => {
+    vi.stubEnv('CHIPPR_LOG_LEVEL', 'verbose');
+    expect(() => loadConfig()).toThrow();
+  });
+});

--- a/tests/util/hash.test.ts
+++ b/tests/util/hash.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { entityId, uniqueId } from '../../src/util/hash.js';
+
+describe('entityId', () => {
+  it('returns a 16-character hex string', () => {
+    const id = entityId('test-input');
+    expect(id).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(entityId('hello')).toBe(entityId('hello'));
+  });
+
+  it('produces different output for different input', () => {
+    expect(entityId('a')).not.toBe(entityId('b'));
+  });
+});
+
+describe('uniqueId', () => {
+  it('returns a 16-character hex string', () => {
+    expect(uniqueId()).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('returns unique values on successive calls', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => uniqueId()));
+    expect(ids.size).toBe(100);
+  });
+});

--- a/tests/util/logger.test.ts
+++ b/tests/util/logger.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { createLogger } from '../../src/util/logger.js';
+
+describe('createLogger', () => {
+  it('creates logger with specified level', () => {
+    const logger = createLogger({ LOG_LEVEL: 'warn' });
+    expect(logger.level).toBe('warn');
+  });
+
+  it('returns pino instance with expected methods', () => {
+    const logger = createLogger({ LOG_LEVEL: 'info' });
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.error).toBe('function');
+    expect(typeof logger.debug).toBe('function');
+  });
+
+  it('handles all valid log levels', () => {
+    for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+      const logger = createLogger({ LOG_LEVEL: level });
+      expect(logger.level).toBe(level);
+    }
+  });
+});

--- a/tests/web/server.test.ts
+++ b/tests/web/server.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { request } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rmSync, existsSync } from 'node:fs';
+import { Store } from '../../src/store/db.js';
+import { Engine } from '../../src/ecs/engine.js';
+import { IngestPipeline } from '../../src/ingest/pipeline.js';
+import { startWebServer } from '../../src/web/server.js';
+import { mockLogger, mockProvider } from '../helpers.js';
+import type { Server } from 'node:http';
+
+function httpRequest(
+  port: number,
+  method: string,
+  path: string,
+  body?: string | Buffer,
+  headers?: Record<string, string>,
+): Promise<{ status: number; body: string; headers: Record<string, string> }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { hostname: '127.0.0.1', port, method, path, headers },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode!,
+            body: Buffer.concat(chunks).toString(),
+            headers: res.headers as Record<string, string>,
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+describe('Web Server', () => {
+  let store: Store;
+  let engine: Engine;
+  let server: Server;
+  let uploadDir: string;
+  let port: number;
+
+  beforeEach(async () => {
+    store = new Store(':memory:');
+    const logger = mockLogger();
+    const provider = mockProvider([]);
+    engine = new Engine(store, provider, logger);
+    uploadDir = join(tmpdir(), `chippr-test-web-${Date.now()}`);
+    const pipeline = new IngestPipeline(engine, logger as any, uploadDir);
+
+    // Use port 0 to get a random available port
+    server = startWebServer({ port: 0, engine, pipeline, logger: logger as any });
+
+    // Wait for server to start and get assigned port
+    await new Promise<void>((resolve) => {
+      server.on('listening', () => {
+        port = (server.address() as { port: number }).port;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    store.close();
+    if (existsSync(uploadDir)) {
+      rmSync(uploadDir, { recursive: true, force: true });
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('GET / serves HTML', async () => {
+    const res = await httpRequest(port, 'GET', '/');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/html');
+  });
+
+  it('POST /api/objective creates entity and emits event', async () => {
+    const res = await httpRequest(
+      port,
+      'POST',
+      '/api/objective',
+      JSON.stringify({ objective: 'Test objective' }),
+      { 'Content-Type': 'application/json' },
+    );
+
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.entityId).toBeDefined();
+    expect(data.objective).toBe('Test objective');
+    expect(engine.entityExists(data.entityId)).toBe(true);
+  });
+
+  it('POST /api/objective rejects invalid JSON', async () => {
+    const res = await httpRequest(
+      port,
+      'POST',
+      '/api/objective',
+      'not json',
+      { 'Content-Type': 'application/json' },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/objective rejects missing objective field', async () => {
+    const res = await httpRequest(
+      port,
+      'POST',
+      '/api/objective',
+      JSON.stringify({ other: 'field' }),
+      { 'Content-Type': 'application/json' },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /api/upload rejects missing boundary', async () => {
+    const res = await httpRequest(
+      port,
+      'POST',
+      '/api/upload',
+      'some data',
+      { 'Content-Type': 'application/octet-stream' },
+    );
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toContain('boundary');
+  });
+
+  it('GET /api/events establishes SSE connection', async () => {
+    // Just verify the headers, don't keep connection open
+    const res = await new Promise<{ status: number; headers: Record<string, string> }>((resolve, reject) => {
+      const req = request(
+        { hostname: '127.0.0.1', port, method: 'GET', path: '/api/events' },
+        (res) => {
+          resolve({
+            status: res.statusCode!,
+            headers: res.headers as Record<string, string>,
+          });
+          res.destroy(); // Close immediately
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('text/event-stream');
+    expect(res.headers['cache-control']).toBe('no-cache');
+  });
+
+  it('GET /api/media returns media list', async () => {
+    const res = await httpRequest(port, 'GET', '/api/media');
+    expect(res.status).toBe(200);
+    const data = JSON.parse(res.body);
+    expect(data.media).toEqual([]);
+  });
+
+  it('GET /api/memory/search rejects missing query', async () => {
+    const res = await httpRequest(port, 'GET', '/api/memory/search');
+    expect(res.status).toBe(400);
+    expect(JSON.parse(res.body).error).toContain('Missing q');
+  });
+
+  it('unknown routes return 404', async () => {
+    const res = await httpRequest(port, 'GET', '/api/nonexistent');
+    expect(res.status).toBe(404);
+  });
+
+  it('CORS headers are present', async () => {
+    const res = await httpRequest(port, 'GET', '/api/media');
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+  });
+
+  it('OPTIONS returns 204', async () => {
+    const res = await httpRequest(port, 'OPTIONS', '/api/upload');
+    expect(res.status).toBe(204);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,6 @@ export default defineConfig({
     globals: true,
     include: ['tests/**/*.test.ts'],
     testTimeout: 10000,
+    teardownTimeout: 5000,
   },
 });


### PR DESCRIPTION
- Create shared test utilities (tests/helpers.ts) with mockLogger, mockProvider, createTestEngine, makeEvent, collectEvents
- Patch 5 error handling gaps:
  - TaskGenerator/Judge: emit system:error on JSON parse failures instead of silent return
  - SystemSelector: emit system:error when LLM returns no tool selection
  - RecursiveImprover: fix listener leak by unregistering task:judged handler after firing
  - Engine: expose off() method for event handler cleanup
- Add 15 new test files covering all previously untested modules:
  - Unit tests: config, hash, logger, provider, claude, local, migrations, entity-creation, task-generator, judge, system-selector, loader, ipc, runner, server
  - E2E tests: objective pipeline, ingest pipeline, web→SSE flow
- Total: 182 tests passing (up from 93), 0 failures
- Coverage: 25/27 source files tested (only pure type definition files excluded)

https://claude.ai/code/session_01HpeSnaPMx96u2ALyP57AC3