### PR TITLE
Add Boyd-correct OODA loop core with multi-level memory and multi-agent orchestration

### DIFF
--- a/src/core/components.ts
+++ b/src/core/components.ts
@@ -1,0 +1,207 @@
+/**
+ * OODA Loop component type definitions.
+ * All components are plain data objects stored via ECS engine.
+ */
+
+// --- Observe Phase ---
+
+export interface SensorComponent {
+  sensorType: string; // 'tool_output' | 'message' | 'file_watcher' | 'action_result' | custom
+  active: boolean;
+  config: Record<string, unknown>;
+}
+
+export interface EnvironmentComponent {
+  variables: Record<string, unknown>;
+  lastUpdated: number;
+}
+
+export interface Observation {
+  source: string;
+  data: unknown;
+  timestamp: number;
+}
+
+export interface ObservationComponent {
+  observations: Observation[];
+  tick: number;
+}
+
+// --- Orient Phase ---
+
+export interface WorldModelComponent {
+  beliefs: Record<string, unknown>;
+  lastUpdated: number;
+  updateCount: number;
+}
+
+export interface ExperienceEntry {
+  id: string;
+  summary: string;
+  outcome: string;
+  noveltyScore: number;
+  tick: number;
+  timestamp: number;
+}
+
+export interface ExperienceComponent {
+  recent: ExperienceEntry[];
+  maxEntries: number;
+}
+
+export interface IdentityComponent {
+  role: string;
+  systemPrompt: string;
+  coreGoals: string[];
+  learnedPreferences: Record<string, string>;
+}
+
+export interface OrientationComponent {
+  situationFrame: string;
+  novelty: number; // 0-1
+  attentionShift: string[];
+  implicitOptions: ActionOption[];
+  tick: number;
+}
+
+export interface AttentionFilterComponent {
+  priorities: string[];
+  activeSensors: string[];
+}
+
+export interface ActionOption {
+  action: string;
+  confidence: number;
+  rationale: string;
+}
+
+// --- Decide Phase ---
+
+export interface GoalComponent {
+  goal: string;
+  priority: number;
+  status: 'active' | 'achieved' | 'abandoned';
+}
+
+export interface ConstraintComponent {
+  constraint: string;
+  hard: boolean; // hard constraints cannot be violated
+}
+
+export interface DecisionComponent {
+  selectedAction: string;
+  rationale: string;
+  deliberate: boolean; // true = System 2 slow path, false = System 1 fast path
+  tick: number;
+}
+
+// --- Act Phase ---
+
+export interface ToolComponent {
+  toolName: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  executor: string; // reference to tool executor id
+}
+
+export interface ActionResultComponent {
+  action: string;
+  success: boolean;
+  result: unknown;
+  error?: string;
+  tick: number;
+  timestamp: number;
+}
+
+// --- Memory ---
+
+export interface WorkingMemoryComponent {
+  observations: Observation[];
+  tickContext: string;
+}
+
+export interface EpisodicMemoryComponent {
+  episodes: Episode[];
+  persistThreshold: number;
+  maxEpisodes: number;
+}
+
+export interface Episode {
+  summary: string;
+  observations: Observation[];
+  decision: string;
+  result: unknown;
+  noveltyScore: number;
+  tick: number;
+  timestamp: number;
+}
+
+export interface SemanticMemoryComponent {
+  entityId: string;
+}
+
+export interface ProceduralMemoryComponent {
+  skills: SkillRecord[];
+}
+
+export interface SkillRecord {
+  id: string;
+  name: string;
+  description: string;
+  preconditions: string[];
+  toolSequence: ToolStep[];
+  successCriteria: string;
+  failureModes: string[];
+  successCount: number;
+  failureCount: number;
+  avgReward: number;
+  source: 'learned' | 'imported' | 'agentskills.io';
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ToolStep {
+  toolName: string;
+  parameters: Record<string, unknown>;
+  description: string;
+}
+
+// --- Tick Metadata ---
+
+export interface TickMetadataComponent {
+  tickNumber: number;
+  startTime: number;
+  phaseDurations: {
+    observe: number;
+    orient: number;
+    decide: number;
+    act: number;
+  };
+  worldModelUpdated: boolean;
+}
+
+// --- Multi-Agent ---
+
+export interface InboxComponent {
+  messages: AgentMessage[];
+}
+
+export interface OutboxComponent {
+  messages: AgentMessage[];
+}
+
+export interface AgentMessage {
+  from: string;
+  to: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  timestamp: number;
+}
+
+export interface ParentAgentComponent {
+  parentEntityId: string;
+}
+
+export interface ChildAgentsComponent {
+  childEntityIds: string[];
+}

--- a/src/core/tick.ts
+++ b/src/core/tick.ts
@@ -1,6 +1,6 @@
 import type { Engine } from '../ecs/engine.js';
 import type { EntityId } from '../ecs/types.js';
-import type { TickMetadataComponent } from './components.js';
+import type { TickMetadataComponent, WorldModelComponent } from './components.js';
 
 export type OodaPhase = 'observe' | 'orient' | 'decide' | 'act';
 
@@ -14,6 +14,7 @@ export interface OodaSystemRef {
 /**
  * Runs one full OODA tick for a single entity.
  * Phases execute sequentially: Observe → Orient → Decide → Act.
+ * Writes TickMetadata.tickNumber before phases so phase systems can read it.
  */
 export async function runOodaTick(
   engine: Engine,
@@ -24,6 +25,18 @@ export async function runOodaTick(
   const startTime = Date.now();
   const durations = { observe: 0, orient: 0, decide: 0, act: 0 };
 
+  // Write tickNumber before phases so ObserveSystem (and others) can read it
+  engine.setComponent(entityId, 'TickMetadata', {
+    tickNumber,
+    startTime,
+    phaseDurations: durations,
+    worldModelUpdated: false,
+  } as unknown as Record<string, unknown>);
+
+  // Capture WorldModel.updateCount before Orient runs
+  const wmBefore = engine.getComponent<WorldModelComponent>(entityId, 'WorldModel');
+  const updateCountBefore = wmBefore?.updateCount ?? 0;
+
   const phases: OodaPhase[] = ['observe', 'orient', 'decide', 'act'];
   for (const phase of phases) {
     const phaseStart = performance.now();
@@ -31,8 +44,9 @@ export async function runOodaTick(
     durations[phase] = Math.round(performance.now() - phaseStart);
   }
 
-  const orientation = engine.getComponent(entityId, 'Orientation');
-  const worldModelUpdated = orientation ? (orientation as Record<string, unknown>).novelty as number > 0.5 : false;
+  // Determine if Orient actually updated the world model (by updateCount delta)
+  const wmAfter = engine.getComponent<WorldModelComponent>(entityId, 'WorldModel');
+  const worldModelUpdated = (wmAfter?.updateCount ?? 0) > updateCountBefore;
 
   const metadata: TickMetadataComponent = {
     tickNumber,

--- a/src/core/tick.ts
+++ b/src/core/tick.ts
@@ -1,0 +1,72 @@
+import type { Engine } from '../ecs/engine.js';
+import type { EntityId } from '../ecs/types.js';
+import type { TickMetadataComponent } from './components.js';
+
+export type OodaPhase = 'observe' | 'orient' | 'decide' | 'act';
+
+export interface OodaSystemRef {
+  observe: (entityId: EntityId) => Promise<void>;
+  orient: (entityId: EntityId) => Promise<void>;
+  decide: (entityId: EntityId) => Promise<void>;
+  act: (entityId: EntityId) => Promise<void>;
+}
+
+/**
+ * Runs one full OODA tick for a single entity.
+ * Phases execute sequentially: Observe → Orient → Decide → Act.
+ */
+export async function runOodaTick(
+  engine: Engine,
+  entityId: EntityId,
+  systems: OodaSystemRef,
+  tickNumber: number,
+): Promise<TickMetadataComponent> {
+  const startTime = Date.now();
+  const durations = { observe: 0, orient: 0, decide: 0, act: 0 };
+
+  const phases: OodaPhase[] = ['observe', 'orient', 'decide', 'act'];
+  for (const phase of phases) {
+    const phaseStart = performance.now();
+    await systems[phase](entityId);
+    durations[phase] = Math.round(performance.now() - phaseStart);
+  }
+
+  const orientation = engine.getComponent(entityId, 'Orientation');
+  const worldModelUpdated = orientation ? (orientation as Record<string, unknown>).novelty as number > 0.5 : false;
+
+  const metadata: TickMetadataComponent = {
+    tickNumber,
+    startTime,
+    phaseDurations: durations,
+    worldModelUpdated,
+  };
+
+  engine.setComponent(entityId, 'TickMetadata', metadata as unknown as Record<string, unknown>);
+
+  engine.emit({
+    type: 'ooda:tick-complete',
+    entityId,
+    data: { tickNumber, durations, worldModelUpdated },
+    source: 'OodaTick',
+    timestamp: Date.now(),
+  });
+
+  return metadata;
+}
+
+/**
+ * Runs OODA ticks for all entities that have an OodaAgent component.
+ */
+export async function runOodaTickAll(
+  engine: Engine,
+  systems: OodaSystemRef,
+  tickNumber: number,
+): Promise<Map<EntityId, TickMetadataComponent>> {
+  const agents = engine.getEntitiesByComponent('OodaAgent');
+  const results = new Map<EntityId, TickMetadataComponent>();
+  for (const entityId of agents) {
+    const meta = await runOodaTick(engine, entityId, systems, tickNumber);
+    results.set(entityId, meta);
+  }
+  return results;
+}

--- a/src/ecs/engine.ts
+++ b/src/ecs/engine.ts
@@ -37,7 +37,7 @@ export class Engine {
     this.store.addComponent(entityId, name, data);
   }
 
-  getComponent<T extends Record<string, unknown> = Record<string, unknown>>(
+  getComponent<T = Record<string, unknown>>(
     entityId: EntityId,
     name: string,
   ): T | null {

--- a/src/model/router.ts
+++ b/src/model/router.ts
@@ -77,15 +77,16 @@ export class ModelProviderRouter implements ModelProvider {
 
   private async timed<T>(name: string, fn: () => Promise<T>): Promise<T> {
     const start = performance.now();
-    const result = await fn();
-    const elapsed = performance.now() - start;
     const s = this.stats.get(name)!;
     s.requests++;
-    s.totalLatencyMs += elapsed;
-    return result;
-  }
-
-  private recordError(name: string): void {
-    this.stats.get(name)!.errors++;
+    try {
+      const result = await fn();
+      s.totalLatencyMs += performance.now() - start;
+      return result;
+    } catch (err) {
+      s.totalLatencyMs += performance.now() - start;
+      s.errors++;
+      throw err;
+    }
   }
 }

--- a/src/model/router.ts
+++ b/src/model/router.ts
@@ -1,0 +1,91 @@
+import type {
+  ModelProvider,
+  ModelMessage,
+  ModelResponse,
+  ToolDefinition,
+  ToolExecutor,
+  AgentEvent,
+} from './types.js';
+
+interface ProviderStats {
+  requests: number;
+  errors: number;
+  totalLatencyMs: number;
+}
+
+/**
+ * Routes between primary and fallback ModelProviders.
+ * Tracks latency and error rates per provider.
+ */
+export class ModelProviderRouter implements ModelProvider {
+  private stats = new Map<string, ProviderStats>();
+
+  constructor(
+    private primary: ModelProvider,
+    private fallback: ModelProvider,
+    private primaryName = 'primary',
+    private fallbackName = 'fallback',
+  ) {
+    this.stats.set(this.primaryName, { requests: 0, errors: 0, totalLatencyMs: 0 });
+    this.stats.set(this.fallbackName, { requests: 0, errors: 0, totalLatencyMs: 0 });
+  }
+
+  async generate(messages: ModelMessage[], tools?: ToolDefinition[]): Promise<ModelResponse> {
+    const s = this.stats.get(this.primaryName)!;
+    s.requests++;
+    const start = performance.now();
+    try {
+      const result = await this.primary.generate(messages, tools);
+      s.totalLatencyMs += performance.now() - start;
+      return result;
+    } catch {
+      s.totalLatencyMs += performance.now() - start;
+      s.errors++;
+      return this.timed(this.fallbackName, () => this.fallback.generate(messages, tools));
+    }
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const provider = this.primary.embed ? this.primary : this.fallback;
+    if (!provider.embed) throw new Error('No provider supports embed()');
+    return provider.embed(text);
+  }
+
+  async *agentLoop(
+    prompt: string,
+    tools: ToolDefinition[],
+    executor: ToolExecutor,
+  ): AsyncGenerator<AgentEvent> {
+    const provider = this.primary.agentLoop ? this.primary : this.fallback;
+    if (!provider.agentLoop) throw new Error('No provider supports agentLoop()');
+    yield* provider.agentLoop(prompt, tools, executor);
+  }
+
+  getStats(): Record<string, ProviderStats> {
+    return Object.fromEntries(this.stats);
+  }
+
+  getErrorRate(name: string): number {
+    const s = this.stats.get(name);
+    return s && s.requests > 0 ? s.errors / s.requests : 0;
+  }
+
+  getAvgLatency(name: string): number {
+    const s = this.stats.get(name);
+    return s && s.requests > 0 ? s.totalLatencyMs / s.requests : 0;
+  }
+
+  private async timed<T>(name: string, fn: () => Promise<T>): Promise<T> {
+    const start = performance.now();
+    const result = await fn();
+    const elapsed = performance.now() - start;
+    const s = this.stats.get(name)!;
+    s.requests++;
+    s.totalLatencyMs += elapsed;
+    return result;
+  }
+
+  private recordError(name: string): void {
+    this.stats.get(name)!.errors++;
+  }
+}

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -36,5 +36,6 @@ export interface AgentEvent {
 
 export interface ModelProvider {
   generate(messages: ModelMessage[], tools?: ToolDefinition[]): Promise<ModelResponse>;
+  embed?(text: string): Promise<number[]>;
   agentLoop?(prompt: string, tools: ToolDefinition[], executor: ToolExecutor): AsyncGenerator<AgentEvent>;
 }

--- a/src/skills/importer.ts
+++ b/src/skills/importer.ts
@@ -1,0 +1,77 @@
+import type { SkillRecord, ToolStep } from '../core/components.js';
+import { uniqueId } from '../util/hash.js';
+
+/**
+ * Parses an agentskills.io markdown skill document into a SkillRecord.
+ * Expects frontmatter-style YAML or markdown sections with:
+ * - Name, Description, Preconditions, Steps, Success Criteria
+ */
+export function importSkillFromMarkdown(markdown: string): SkillRecord {
+  const name = extractSection(markdown, 'name') ?? extractHeading(markdown) ?? 'imported-skill';
+  const description = extractSection(markdown, 'description') ?? '';
+  const preconditions = extractList(markdown, 'preconditions');
+  const steps = extractSteps(markdown);
+  const successCriteria = extractSection(markdown, 'success criteria') ?? '';
+  const failureModes = extractList(markdown, 'failure modes');
+
+  return {
+    id: uniqueId(),
+    name,
+    description,
+    preconditions,
+    toolSequence: steps,
+    successCriteria,
+    failureModes,
+    successCount: 0,
+    failureCount: 0,
+    avgReward: 0.5, // neutral starting reward for imported skills
+    source: 'agentskills.io',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+/**
+ * Fetches a skill from a remote URL and imports it.
+ */
+export async function fetchAndImportSkill(url: string): Promise<SkillRecord> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to fetch skill from ${url}: ${response.status}`);
+  const markdown = await response.text();
+  return importSkillFromMarkdown(markdown);
+}
+
+function extractHeading(md: string): string | null {
+  const match = md.match(/^#\s+(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+function extractSection(md: string, sectionName: string): string | null {
+  const regex = new RegExp(`##\\s*${sectionName}\\s*\\n([\\s\\S]*?)(?=\\n##|$)`, 'i');
+  const match = md.match(regex);
+  return match ? match[1].trim() : null;
+}
+
+function extractList(md: string, sectionName: string): string[] {
+  const section = extractSection(md, sectionName);
+  if (!section) return [];
+  return section
+    .split('\n')
+    .map((line) => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean);
+}
+
+function extractSteps(md: string): ToolStep[] {
+  const section = extractSection(md, 'steps') ?? extractSection(md, 'tool sequence');
+  if (!section) return [];
+
+  return section
+    .split('\n')
+    .map((line) => line.replace(/^\d+\.\s*/, '').replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean)
+    .map((step) => ({
+      toolName: 'generic',
+      parameters: {},
+      description: step,
+    }));
+}

--- a/src/store/db.ts
+++ b/src/store/db.ts
@@ -55,7 +55,7 @@ export class Store {
       .run(entityId, name, JSON.stringify(data));
   }
 
-  getComponent<T extends Record<string, unknown> = Record<string, unknown>>(
+  getComponent<T = Record<string, unknown>>(
     entityId: EntityId,
     name: string,
   ): T | null {

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -245,6 +245,42 @@ export class MemoryStore {
     }
   }
 
+  getProceduralById(id: string): ProceduralEntry | null {
+    const row = this.db
+      .prepare(
+        'SELECT id, entity_id, skill_name, description, tool_sequence, success_count, failure_count, avg_reward, source, created_at, updated_at FROM procedural_memory WHERE id = ?',
+      )
+      .get(id) as {
+      id: string;
+      entity_id: string;
+      skill_name: string;
+      description: string | null;
+      tool_sequence: string | null;
+      success_count: number;
+      failure_count: number;
+      avg_reward: number;
+      source: string | null;
+      created_at: number;
+      updated_at: number;
+    } | undefined;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      entityId: row.entity_id,
+      skillName: row.skill_name,
+      description: row.description,
+      toolSequence: row.tool_sequence ? JSON.parse(row.tool_sequence) : [],
+      successCount: row.success_count,
+      failureCount: row.failure_count,
+      avgReward: row.avg_reward,
+      source: row.source,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
   getProceduralByName(entityId: EntityId, skillName: string): ProceduralEntry | null {
     const row = this.db
       .prepare(

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -1,0 +1,316 @@
+import type Database from 'better-sqlite3';
+import type { EntityId } from '../ecs/types.js';
+import { serializeEmbedding, deserializeEmbedding, cosineSimilarity } from '../model/embedding.js';
+
+export interface SemanticEntry {
+  id: string;
+  entityId: string;
+  content: string;
+  category: string | null;
+  score?: number;
+  createdAt: number;
+  lastAccessed: number;
+  accessCount: number;
+}
+
+export interface EpisodicEntry {
+  id: string;
+  entityId: string;
+  episodeSummary: string;
+  fullEpisode: string | null;
+  noveltyScore: number | null;
+  tickNumber: number | null;
+  createdAt: number;
+}
+
+export interface ProceduralEntry {
+  id: string;
+  entityId: string;
+  skillName: string;
+  description: string | null;
+  toolSequence: unknown[];
+  successCount: number;
+  failureCount: number;
+  avgReward: number;
+  source: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Query helpers for the OODA memory tables.
+ */
+export class MemoryStore {
+  constructor(private db: Database.Database) {}
+
+  // --- Semantic Memory ---
+
+  addSemantic(entityId: EntityId, id: string, content: string, category?: string, embedding?: number[]): void {
+    this.db
+      .prepare(
+        'INSERT OR REPLACE INTO semantic_memory (id, entity_id, content, category, embedding) VALUES (?, ?, ?, ?, ?)',
+      )
+      .run(id, entityId, content, category ?? null, embedding ? serializeEmbedding(embedding) : null);
+  }
+
+  searchSemantic(entityId: EntityId, queryEmbedding: number[], limit = 10): SemanticEntry[] {
+    const rows = this.db
+      .prepare(
+        'SELECT id, entity_id, content, category, embedding, created_at, last_accessed, access_count FROM semantic_memory WHERE entity_id = ? AND embedding IS NOT NULL',
+      )
+      .all(entityId) as Array<{
+      id: string;
+      entity_id: string;
+      content: string;
+      category: string | null;
+      embedding: Buffer;
+      created_at: number;
+      last_accessed: number;
+      access_count: number;
+    }>;
+
+    const scored = rows.map((row) => ({
+      id: row.id,
+      entityId: row.entity_id,
+      content: row.content,
+      category: row.category,
+      score: cosineSimilarity(queryEmbedding, deserializeEmbedding(row.embedding)),
+      createdAt: row.created_at,
+      lastAccessed: row.last_accessed,
+      accessCount: row.access_count,
+    }));
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit);
+  }
+
+  touchSemantic(id: string): void {
+    this.db
+      .prepare('UPDATE semantic_memory SET last_accessed = unixepoch(), access_count = access_count + 1 WHERE id = ?')
+      .run(id);
+  }
+
+  // --- Episodic Memory ---
+
+  addEpisodic(
+    entityId: EntityId,
+    id: string,
+    summary: string,
+    fullEpisode?: unknown,
+    noveltyScore?: number,
+    tickNumber?: number,
+    embedding?: number[],
+  ): void {
+    this.db
+      .prepare(
+        'INSERT OR REPLACE INTO episodic_memory (id, entity_id, episode_summary, full_episode, novelty_score, tick_number, embedding) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      )
+      .run(
+        id,
+        entityId,
+        summary,
+        fullEpisode ? JSON.stringify(fullEpisode) : null,
+        noveltyScore ?? null,
+        tickNumber ?? null,
+        embedding ? serializeEmbedding(embedding) : null,
+      );
+  }
+
+  getEpisodicByEntity(entityId: EntityId, limit = 20): EpisodicEntry[] {
+    const rows = this.db
+      .prepare(
+        'SELECT id, entity_id, episode_summary, full_episode, novelty_score, tick_number, created_at FROM episodic_memory WHERE entity_id = ? ORDER BY created_at DESC, rowid DESC LIMIT ?',
+      )
+      .all(entityId, limit) as Array<{
+      id: string;
+      entity_id: string;
+      episode_summary: string;
+      full_episode: string | null;
+      novelty_score: number | null;
+      tick_number: number | null;
+      created_at: number;
+    }>;
+
+    return rows.map((r) => ({
+      id: r.id,
+      entityId: r.entity_id,
+      episodeSummary: r.episode_summary,
+      fullEpisode: r.full_episode,
+      noveltyScore: r.novelty_score,
+      tickNumber: r.tick_number,
+      createdAt: r.created_at,
+    }));
+  }
+
+  searchEpisodic(entityId: EntityId, queryEmbedding: number[], limit = 10): (EpisodicEntry & { score: number })[] {
+    const rows = this.db
+      .prepare(
+        'SELECT id, entity_id, episode_summary, full_episode, novelty_score, tick_number, embedding, created_at FROM episodic_memory WHERE entity_id = ? AND embedding IS NOT NULL',
+      )
+      .all(entityId) as Array<{
+      id: string;
+      entity_id: string;
+      episode_summary: string;
+      full_episode: string | null;
+      novelty_score: number | null;
+      tick_number: number | null;
+      embedding: Buffer;
+      created_at: number;
+    }>;
+
+    const scored = rows.map((r) => ({
+      id: r.id,
+      entityId: r.entity_id,
+      episodeSummary: r.episode_summary,
+      fullEpisode: r.full_episode,
+      noveltyScore: r.novelty_score,
+      tickNumber: r.tick_number,
+      createdAt: r.created_at,
+      score: cosineSimilarity(queryEmbedding, deserializeEmbedding(r.embedding)),
+    }));
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit);
+  }
+
+  // --- Procedural Memory ---
+
+  addProcedural(
+    entityId: EntityId,
+    id: string,
+    skillName: string,
+    description?: string,
+    toolSequence?: unknown[],
+    source?: string,
+  ): void {
+    this.db
+      .prepare(
+        'INSERT OR REPLACE INTO procedural_memory (id, entity_id, skill_name, description, tool_sequence, source) VALUES (?, ?, ?, ?, ?, ?)',
+      )
+      .run(id, entityId, skillName, description ?? null, toolSequence ? JSON.stringify(toolSequence) : null, source ?? null);
+  }
+
+  getProceduralByEntity(entityId: EntityId): ProceduralEntry[] {
+    const rows = this.db
+      .prepare(
+        'SELECT id, entity_id, skill_name, description, tool_sequence, success_count, failure_count, avg_reward, source, created_at, updated_at FROM procedural_memory WHERE entity_id = ? ORDER BY avg_reward DESC',
+      )
+      .all(entityId) as Array<{
+      id: string;
+      entity_id: string;
+      skill_name: string;
+      description: string | null;
+      tool_sequence: string | null;
+      success_count: number;
+      failure_count: number;
+      avg_reward: number;
+      source: string | null;
+      created_at: number;
+      updated_at: number;
+    }>;
+
+    return rows.map((r) => ({
+      id: r.id,
+      entityId: r.entity_id,
+      skillName: r.skill_name,
+      description: r.description,
+      toolSequence: r.tool_sequence ? JSON.parse(r.tool_sequence) : [],
+      successCount: r.success_count,
+      failureCount: r.failure_count,
+      avgReward: r.avg_reward,
+      source: r.source,
+      createdAt: r.created_at,
+      updatedAt: r.updated_at,
+    }));
+  }
+
+  updateProceduralStats(id: string, success: boolean, reward: number): void {
+    const row = this.db
+      .prepare('SELECT success_count, failure_count, avg_reward FROM procedural_memory WHERE id = ?')
+      .get(id) as { success_count: number; failure_count: number; avg_reward: number } | undefined;
+
+    if (!row) return;
+
+    const alpha = 0.3; // EMA smoothing factor
+    const newAvgReward = row.avg_reward * (1 - alpha) + reward * alpha;
+
+    if (success) {
+      this.db
+        .prepare('UPDATE procedural_memory SET success_count = success_count + 1, avg_reward = ?, updated_at = unixepoch() WHERE id = ?')
+        .run(newAvgReward, id);
+    } else {
+      this.db
+        .prepare('UPDATE procedural_memory SET failure_count = failure_count + 1, avg_reward = ?, updated_at = unixepoch() WHERE id = ?')
+        .run(newAvgReward, id);
+    }
+  }
+
+  getProceduralByName(entityId: EntityId, skillName: string): ProceduralEntry | null {
+    const row = this.db
+      .prepare(
+        'SELECT id, entity_id, skill_name, description, tool_sequence, success_count, failure_count, avg_reward, source, created_at, updated_at FROM procedural_memory WHERE entity_id = ? AND skill_name = ?',
+      )
+      .get(entityId, skillName) as {
+      id: string;
+      entity_id: string;
+      skill_name: string;
+      description: string | null;
+      tool_sequence: string | null;
+      success_count: number;
+      failure_count: number;
+      avg_reward: number;
+      source: string | null;
+      created_at: number;
+      updated_at: number;
+    } | undefined;
+
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      entityId: row.entity_id,
+      skillName: row.skill_name,
+      description: row.description,
+      toolSequence: row.tool_sequence ? JSON.parse(row.tool_sequence) : [],
+      successCount: row.success_count,
+      failureCount: row.failure_count,
+      avgReward: row.avg_reward,
+      source: row.source,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  // --- Entity Snapshots ---
+
+  saveSnapshot(entityId: EntityId, components: Record<string, unknown>, timestamp?: number): void {
+    this.db
+      .prepare('INSERT OR REPLACE INTO entity_snapshots (entity_id, snapshot_time, components) VALUES (?, ?, ?)')
+      .run(entityId, timestamp ?? Date.now(), JSON.stringify(components));
+  }
+
+  getLatestSnapshot(entityId: EntityId): { components: Record<string, unknown>; snapshotTime: number } | null {
+    const row = this.db
+      .prepare('SELECT components, snapshot_time FROM entity_snapshots WHERE entity_id = ? ORDER BY snapshot_time DESC LIMIT 1')
+      .get(entityId) as { components: string; snapshot_time: number } | undefined;
+
+    return row ? { components: JSON.parse(row.components), snapshotTime: row.snapshot_time } : null;
+  }
+
+  getAllLatestSnapshots(): Array<{ entityId: string; components: Record<string, unknown>; snapshotTime: number }> {
+    const rows = this.db
+      .prepare(
+        `SELECT es.entity_id, es.components, es.snapshot_time
+         FROM entity_snapshots es
+         INNER JOIN (SELECT entity_id, MAX(snapshot_time) as max_time FROM entity_snapshots GROUP BY entity_id) latest
+         ON es.entity_id = latest.entity_id AND es.snapshot_time = latest.max_time`,
+      )
+      .all() as Array<{ entity_id: string; components: string; snapshot_time: number }>;
+
+    return rows.map((r) => ({
+      entityId: r.entity_id,
+      components: JSON.parse(r.components),
+      snapshotTime: r.snapshot_time,
+    }));
+  }
+}

--- a/src/store/migrations.ts
+++ b/src/store/migrations.ts
@@ -78,6 +78,64 @@ const MIGRATIONS = [
       CREATE INDEX IF NOT EXISTS idx_media_source ON media(source);
     `,
   },
+  {
+    version: 3,
+    up: `
+      CREATE TABLE IF NOT EXISTS semantic_memory (
+        id TEXT PRIMARY KEY,
+        entity_id TEXT NOT NULL,
+        content TEXT NOT NULL,
+        category TEXT,
+        embedding BLOB,
+        created_at INTEGER DEFAULT (unixepoch()),
+        last_accessed INTEGER DEFAULT (unixepoch()),
+        access_count INTEGER DEFAULT 0
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_semantic_entity ON semantic_memory(entity_id);
+      CREATE INDEX IF NOT EXISTS idx_semantic_category ON semantic_memory(category);
+
+      CREATE TABLE IF NOT EXISTS episodic_memory (
+        id TEXT PRIMARY KEY,
+        entity_id TEXT NOT NULL,
+        episode_summary TEXT NOT NULL,
+        full_episode TEXT,
+        novelty_score REAL,
+        embedding BLOB,
+        tick_number INTEGER,
+        created_at INTEGER DEFAULT (unixepoch())
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_episodic_entity ON episodic_memory(entity_id);
+      CREATE INDEX IF NOT EXISTS idx_episodic_novelty ON episodic_memory(novelty_score);
+
+      CREATE TABLE IF NOT EXISTS procedural_memory (
+        id TEXT PRIMARY KEY,
+        entity_id TEXT NOT NULL,
+        skill_name TEXT NOT NULL,
+        description TEXT,
+        tool_sequence TEXT,
+        success_count INTEGER DEFAULT 0,
+        failure_count INTEGER DEFAULT 0,
+        avg_reward REAL DEFAULT 0.0,
+        source TEXT,
+        created_at INTEGER DEFAULT (unixepoch()),
+        updated_at INTEGER DEFAULT (unixepoch())
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_procedural_entity ON procedural_memory(entity_id);
+      CREATE INDEX IF NOT EXISTS idx_procedural_skill ON procedural_memory(skill_name);
+
+      CREATE TABLE IF NOT EXISTS entity_snapshots (
+        entity_id TEXT NOT NULL,
+        snapshot_time INTEGER NOT NULL,
+        components TEXT NOT NULL,
+        PRIMARY KEY (entity_id, snapshot_time)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_snapshots_entity ON entity_snapshots(entity_id);
+    `,
+  },
 ];
 
 export function runMigrations(db: Database.Database): void {

--- a/src/systems/act.ts
+++ b/src/systems/act.ts
@@ -1,0 +1,94 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System, EntityId } from '../ecs/types.js';
+import type {
+  DecisionComponent,
+  ActionResultComponent,
+} from '../core/components.js';
+
+/**
+ * ActSystem: Executes the decided action using available tool components.
+ * Results become input to ObserveSystem on the next tick.
+ */
+export function createActSystem(engine: Engine): System {
+  return {
+    name: 'ActSystem',
+    version: '1.0.0',
+    type: 'core',
+    description: 'Executes decided actions and writes results for next observation cycle',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'ooda:act') {
+        await act(engine, event.entityId);
+      }
+    },
+  };
+}
+
+export async function act(engine: Engine, entityId: EntityId): Promise<void> {
+  const logger = engine.getLogger();
+
+  const decision = engine.getComponent<DecisionComponent>(entityId, 'Decision');
+  if (!decision) {
+    logger.warn({ entityId }, 'ActSystem: no decision available');
+    return;
+  }
+
+  if (decision.selectedAction === 'no-op') {
+    engine.setComponent(entityId, 'ActionResult', {
+      action: 'no-op',
+      success: true,
+      result: null,
+      tick: decision.tick,
+      timestamp: Date.now(),
+    } as unknown as Record<string, unknown>);
+    return;
+  }
+
+  const now = Date.now();
+
+  try {
+    // Route the action through the ECS event system
+    // Other systems (or tool executors) can listen for action:execute events
+    engine.emit({
+      type: 'action:execute',
+      entityId,
+      data: {
+        action: decision.selectedAction,
+        rationale: decision.rationale,
+        deliberate: decision.deliberate,
+      },
+      source: 'ActSystem',
+      timestamp: now,
+    });
+
+    const result: ActionResultComponent = {
+      action: decision.selectedAction,
+      success: true,
+      result: { executed: true, action: decision.selectedAction },
+      tick: decision.tick,
+      timestamp: now,
+    };
+
+    engine.setComponent(entityId, 'ActionResult', result as unknown as Record<string, unknown>);
+
+    logger.debug({ entityId, action: decision.selectedAction }, 'ActSystem: action executed');
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    const result: ActionResultComponent = {
+      action: decision.selectedAction,
+      success: false,
+      result: null,
+      error,
+      tick: decision.tick,
+      timestamp: now,
+    };
+
+    engine.setComponent(entityId, 'ActionResult', result as unknown as Record<string, unknown>);
+
+    logger.error({ entityId, action: decision.selectedAction, error }, 'ActSystem: action failed');
+  }
+}
+
+export default createActSystem;

--- a/src/systems/decide.ts
+++ b/src/systems/decide.ts
@@ -5,6 +5,7 @@ import type {
   GoalComponent,
   ConstraintComponent,
   DecisionComponent,
+  ActionOption,
 } from '../core/components.js';
 
 /**
@@ -47,19 +48,25 @@ export async function decide(engine: Engine, entityId: EntityId): Promise<void> 
   let decision: DecisionComponent;
 
   if (orientation.novelty < NOVELTY_THRESHOLD && orientation.implicitOptions.length > 0) {
-    // Fast path — pick highest confidence implicit option that satisfies goals
-    const bestOption = orientation.implicitOptions.reduce((best, opt) =>
-      opt.confidence > best.confidence ? opt : best,
-    );
+    // Fast path — pick highest confidence option that doesn't violate hard constraints
+    const viable = filterByConstraints(orientation.implicitOptions, constraints);
+    const bestOption = viable.length > 0
+      ? viable.reduce((best, opt) => opt.confidence > best.confidence ? opt : best)
+      : null;
 
-    decision = {
-      selectedAction: bestOption.action,
-      rationale: `Fast path (novelty=${orientation.novelty.toFixed(2)}): ${bestOption.rationale}`,
-      deliberate: false,
-      tick: orientation.tick,
-    };
-
-    logger.debug({ entityId, action: decision.selectedAction }, 'DecideSystem: fast path');
+    if (bestOption) {
+      decision = {
+        selectedAction: bestOption.action,
+        rationale: `Fast path (novelty=${orientation.novelty.toFixed(2)}): ${bestOption.rationale}`,
+        deliberate: false,
+        tick: orientation.tick,
+      };
+      logger.debug({ entityId, action: decision.selectedAction }, 'DecideSystem: fast path');
+    } else {
+      // All options violate constraints — escalate to deliberate path
+      decision = await deliberate(engine, entityId, orientation, goals, constraints);
+      logger.debug({ entityId, action: decision.selectedAction }, 'DecideSystem: fast path escalated to deliberate (constraint violation)');
+    }
   } else {
     // Slow path — deliberate via ModelProvider
     decision = await deliberate(engine, entityId, orientation, goals, constraints);
@@ -121,6 +128,20 @@ Respond with valid JSON:
       tick: orientation.tick,
     };
   }
+}
+
+/**
+ * Filters implicit options against hard constraints.
+ * An option is excluded if its action text matches a hard constraint keyword.
+ * When no constraints exist, all options pass through.
+ */
+function filterByConstraints(
+  options: ActionOption[],
+  constraints: ConstraintComponent | null,
+): ActionOption[] {
+  if (!constraints?.hard) return options;
+  const forbidden = String(constraints.constraint).toLowerCase();
+  return options.filter((opt) => !opt.action.toLowerCase().includes(forbidden));
 }
 
 export default createDecideSystem;

--- a/src/systems/decide.ts
+++ b/src/systems/decide.ts
@@ -1,0 +1,126 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System, EntityId } from '../ecs/types.js';
+import type {
+  OrientationComponent,
+  GoalComponent,
+  ConstraintComponent,
+  DecisionComponent,
+} from '../core/components.js';
+
+/**
+ * DecideSystem: Selects an action based on orientation.
+ * Low novelty + matching implicit options → fast path (System 1).
+ * High novelty → deliberate evaluation via ModelProvider (System 2).
+ */
+export function createDecideSystem(engine: Engine): System {
+  return {
+    name: 'DecideSystem',
+    version: '1.0.0',
+    type: 'core',
+    description: 'Selects action from orientation — fast path for routine, deliberate for novel',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'ooda:decide') {
+        await decide(engine, event.entityId);
+      }
+    },
+  };
+}
+
+const NOVELTY_THRESHOLD = 0.4;
+
+export async function decide(engine: Engine, entityId: EntityId): Promise<void> {
+  const logger = engine.getLogger();
+
+  const orientation = engine.getComponent<OrientationComponent>(entityId, 'Orientation');
+  if (!orientation) {
+    logger.warn({ entityId }, 'DecideSystem: no orientation available');
+    return;
+  }
+
+  // Gather goals and constraints
+  const goals = engine.getComponent<GoalComponent>(entityId, 'Goals');
+  const constraints = engine.getComponent<ConstraintComponent>(entityId, 'Constraints');
+
+  let decision: DecisionComponent;
+
+  if (orientation.novelty < NOVELTY_THRESHOLD && orientation.implicitOptions.length > 0) {
+    // Fast path — pick highest confidence implicit option that satisfies goals
+    const bestOption = orientation.implicitOptions.reduce((best, opt) =>
+      opt.confidence > best.confidence ? opt : best,
+    );
+
+    decision = {
+      selectedAction: bestOption.action,
+      rationale: `Fast path (novelty=${orientation.novelty.toFixed(2)}): ${bestOption.rationale}`,
+      deliberate: false,
+      tick: orientation.tick,
+    };
+
+    logger.debug({ entityId, action: decision.selectedAction }, 'DecideSystem: fast path');
+  } else {
+    // Slow path — deliberate via ModelProvider
+    decision = await deliberate(engine, entityId, orientation, goals, constraints);
+    logger.debug({ entityId, action: decision.selectedAction }, 'DecideSystem: deliberate path');
+  }
+
+  engine.setComponent(entityId, 'Decision', decision as unknown as Record<string, unknown>);
+}
+
+async function deliberate(
+  engine: Engine,
+  entityId: EntityId,
+  orientation: OrientationComponent,
+  goals: GoalComponent | null,
+  constraints: ConstraintComponent | null,
+): Promise<DecisionComponent> {
+  const provider = engine.getProvider();
+
+  const systemPrompt = `You are the Decision phase of a Boyd OODA loop. The Orientation phase flagged high novelty, requiring careful deliberation.
+
+Evaluate the implicit options against the agent's goals and constraints. You may also propose a new action not in the implicit options.
+
+Respond with valid JSON:
+{
+  "selectedAction": "string — the action to take",
+  "rationale": "string — why this action was chosen"
+}`;
+
+  const userContent = JSON.stringify({
+    situationFrame: orientation.situationFrame,
+    novelty: orientation.novelty,
+    implicitOptions: orientation.implicitOptions,
+    goals: goals ?? null,
+    constraints: constraints ?? null,
+  });
+
+  try {
+    const response = await provider.generate([
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userContent },
+    ]);
+
+    const jsonMatch = response.content.match(/```(?:json)?\s*([\s\S]*?)```/) ?? [null, response.content];
+    const parsed = JSON.parse((jsonMatch[1] ?? response.content).trim());
+
+    return {
+      selectedAction: String(parsed.selectedAction ?? 'no-op'),
+      rationale: `Deliberate (novelty=${orientation.novelty.toFixed(2)}): ${parsed.rationale ?? 'no rationale'}`,
+      deliberate: true,
+      tick: orientation.tick,
+    };
+  } catch {
+    // Fallback: pick best implicit option or no-op
+    const best = orientation.implicitOptions[0];
+    return {
+      selectedAction: best?.action ?? 'no-op',
+      rationale: 'Deliberation failed — falling back to top implicit option',
+      deliberate: true,
+      tick: orientation.tick,
+    };
+  }
+}
+
+export default createDecideSystem;

--- a/src/systems/memory-persistence.ts
+++ b/src/systems/memory-persistence.ts
@@ -66,10 +66,12 @@ async function persistMemory(engine: Engine, memoryStore: MemoryStore, entityId:
   // Add to ring buffer
   episodic.episodes.push(episode);
 
-  // Prune if buffer is full — keep high-novelty episodes
+  // Prune if buffer is full — keep high-novelty episodes while preserving chronological order
   if (episodic.episodes.length > episodic.maxEpisodes) {
-    episodic.episodes.sort((a, b) => b.noveltyScore - a.noveltyScore);
-    episodic.episodes = episodic.episodes.slice(0, episodic.maxEpisodes);
+    const indexed = episodic.episodes.map((ep, idx) => ({ ep, idx }));
+    indexed.sort((a, b) => b.ep.noveltyScore - a.ep.noveltyScore);
+    const keepIndices = new Set(indexed.slice(0, episodic.maxEpisodes).map((item) => item.idx));
+    episodic.episodes = episodic.episodes.filter((_, idx) => keepIndices.has(idx));
   }
 
   engine.setComponent(entityId, 'EpisodicMemory', episodic as unknown as Record<string, unknown>);

--- a/src/systems/memory-persistence.ts
+++ b/src/systems/memory-persistence.ts
@@ -1,0 +1,107 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System, EntityId } from '../ecs/types.js';
+import type {
+  OrientationComponent,
+  ObservationComponent,
+  DecisionComponent,
+  ActionResultComponent,
+  EpisodicMemoryComponent,
+  Episode,
+} from '../core/components.js';
+import { MemoryStore } from '../store/memory-store.js';
+import { uniqueId } from '../util/hash.js';
+
+/**
+ * MemoryPersistenceSystem: Runs after ActSystem each tick.
+ * Persists high-novelty episodes to episodic memory in SQLite.
+ * Manages the episodic ring buffer.
+ */
+export function createMemoryPersistenceSystem(engine: Engine): System {
+  const memoryStore = new MemoryStore(engine.getStore().db);
+
+  return {
+    name: 'MemoryPersistenceSystem',
+    version: '1.0.0',
+    type: 'core',
+    description: 'Persists high-novelty episodes to long-term memory after each OODA tick',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'ooda:tick-complete') {
+        await persistMemory(engine, memoryStore, event.entityId);
+      }
+    },
+  };
+}
+
+async function persistMemory(engine: Engine, memoryStore: MemoryStore, entityId: EntityId): Promise<void> {
+  const logger = engine.getLogger();
+
+  const orientation = engine.getComponent<OrientationComponent>(entityId, 'Orientation');
+  const observation = engine.getComponent<ObservationComponent>(entityId, 'Observation');
+  const decision = engine.getComponent<DecisionComponent>(entityId, 'Decision');
+  const actionResult = engine.getComponent<ActionResultComponent>(entityId, 'ActionResult');
+
+  if (!orientation || !observation) return;
+
+  // Get or create episodic memory component
+  const episodic = engine.getComponent<EpisodicMemoryComponent>(entityId, 'EpisodicMemory') ?? {
+    episodes: [],
+    persistThreshold: 0.5,
+    maxEpisodes: 50,
+  };
+
+  // Build episode from current tick
+  const episode: Episode = {
+    summary: orientation.situationFrame,
+    observations: observation.observations,
+    decision: decision?.selectedAction ?? 'none',
+    result: actionResult?.result ?? null,
+    noveltyScore: orientation.novelty,
+    tick: orientation.tick,
+    timestamp: Date.now(),
+  };
+
+  // Add to ring buffer
+  episodic.episodes.push(episode);
+
+  // Prune if buffer is full — keep high-novelty episodes
+  if (episodic.episodes.length > episodic.maxEpisodes) {
+    episodic.episodes.sort((a, b) => b.noveltyScore - a.noveltyScore);
+    episodic.episodes = episodic.episodes.slice(0, episodic.maxEpisodes);
+  }
+
+  engine.setComponent(entityId, 'EpisodicMemory', episodic as unknown as Record<string, unknown>);
+
+  // Persist to SQLite if novelty exceeds threshold
+  if (orientation.novelty >= episodic.persistThreshold) {
+    const provider = engine.getProvider();
+    let embedding: number[] | undefined;
+
+    if (provider.embed) {
+      try {
+        embedding = await provider.embed(episode.summary);
+      } catch {
+        // embedding is optional
+      }
+    }
+
+    memoryStore.addEpisodic(
+      entityId,
+      uniqueId(),
+      episode.summary,
+      { observations: episode.observations, decision: episode.decision, result: episode.result },
+      orientation.novelty,
+      orientation.tick,
+      embedding,
+    );
+
+    logger.debug(
+      { entityId, novelty: orientation.novelty, tick: orientation.tick },
+      'MemoryPersistence: episode persisted',
+    );
+  }
+}
+
+export default createMemoryPersistenceSystem;

--- a/src/systems/messaging.ts
+++ b/src/systems/messaging.ts
@@ -1,0 +1,70 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System } from '../ecs/types.js';
+import type { OutboxComponent, InboxComponent, AgentMessage } from '../core/components.js';
+
+/**
+ * InterAgentMessageSystem: Routes messages between agent entities.
+ * Messages in an agent's Outbox are delivered to the target's Inbox.
+ * Messages flow through the receiver's ObserveSystem like any other signal.
+ */
+export function createInterAgentMessageSystem(engine: Engine): System {
+  return {
+    name: 'InterAgentMessageSystem',
+    version: '1.0.0',
+    type: 'core',
+    description: 'Routes asynchronous messages between agent entities via Outbox → Inbox',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'messaging:flush') {
+        flushMessages(engine);
+      } else if (event.type === 'message:send') {
+        const msg = event.data as AgentMessage;
+        deliverMessage(engine, msg);
+      }
+    },
+  };
+}
+
+/**
+ * Flush all outbox messages across all entities.
+ * Call this between OODA ticks to deliver inter-agent messages.
+ */
+export function flushMessages(engine: Engine): void {
+  const logger = engine.getLogger();
+  const outboxEntities = engine.getEntitiesByComponent('Outbox');
+  let delivered = 0;
+
+  for (const senderId of outboxEntities) {
+    const outbox = engine.getComponent<OutboxComponent>(senderId, 'Outbox');
+    if (!outbox || outbox.messages.length === 0) continue;
+
+    for (const msg of outbox.messages) {
+      deliverMessage(engine, msg);
+      delivered++;
+    }
+
+    // Clear outbox after delivery
+    engine.setComponent(senderId, 'Outbox', { messages: [] } as unknown as Record<string, unknown>);
+  }
+
+  if (delivered > 0) {
+    logger.debug({ delivered }, 'Messaging: flushed messages');
+  }
+}
+
+function deliverMessage(engine: Engine, msg: AgentMessage): void {
+  const logger = engine.getLogger();
+
+  if (!engine.entityExists(msg.to)) {
+    logger.warn({ to: msg.to, from: msg.from }, 'Messaging: target entity does not exist');
+    return;
+  }
+
+  const inbox = engine.getComponent<InboxComponent>(msg.to, 'Inbox') ?? { messages: [] };
+  inbox.messages.push(msg);
+  engine.setComponent(msg.to, 'Inbox', inbox as unknown as Record<string, unknown>);
+}
+
+export default createInterAgentMessageSystem;

--- a/src/systems/messaging.ts
+++ b/src/systems/messaging.ts
@@ -20,7 +20,7 @@ export function createInterAgentMessageSystem(engine: Engine): System {
       if (event.type === 'messaging:flush') {
         flushMessages(engine);
       } else if (event.type === 'message:send') {
-        const msg = event.data as AgentMessage;
+        const msg = event.data as unknown as AgentMessage;
         deliverMessage(engine, msg);
       }
     },

--- a/src/systems/observe.ts
+++ b/src/systems/observe.ts
@@ -1,0 +1,101 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System, EntityId } from '../ecs/types.js';
+import type {
+  SensorComponent,
+  AttentionFilterComponent,
+  ActionResultComponent,
+  Observation,
+  ObservationComponent,
+  InboxComponent,
+} from '../core/components.js';
+
+/**
+ * ObserveSystem: Gathers raw inputs from all active sensor components.
+ * What sensors are active is determined by AttentionFilterComponent
+ * from the previous Orient phase (Boyd's feedback arrow).
+ */
+export function createObserveSystem(engine: Engine): System {
+  return {
+    name: 'ObserveSystem',
+    version: '1.0.0',
+    type: 'core',
+    description: 'Gathers raw observations from active sensors on an entity',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'ooda:observe') {
+        await observe(engine, event.entityId);
+      }
+    },
+  };
+}
+
+export async function observe(engine: Engine, entityId: EntityId): Promise<void> {
+  const logger = engine.getLogger();
+  const observations: Observation[] = [];
+  const now = Date.now();
+
+  // Get attention filter to determine which sensors to read
+  const attentionFilter = engine.getComponent<AttentionFilterComponent>(entityId, 'AttentionFilter');
+  const activeSensors = attentionFilter?.activeSensors ?? [];
+
+  // Collect from sensor components
+  const sensorEntities = engine.getEntitiesByComponent('Sensor');
+  for (const sensorEntityId of sensorEntities) {
+    // Only read sensors attached to this entity or global sensors
+    if (sensorEntityId !== entityId) continue;
+
+    const sensor = engine.getComponent<SensorComponent>(sensorEntityId, 'Sensor');
+    if (!sensor || !sensor.active) continue;
+
+    // If attention filter exists, only read prioritized sensor types
+    if (activeSensors.length > 0 && !activeSensors.includes(sensor.sensorType)) continue;
+
+    observations.push({
+      source: sensor.sensorType,
+      data: sensor.config,
+      timestamp: now,
+    });
+  }
+
+  // Collect from previous action results
+  const actionResult = engine.getComponent<ActionResultComponent>(entityId, 'ActionResult');
+  if (actionResult) {
+    observations.push({
+      source: 'action_result',
+      data: {
+        action: actionResult.action,
+        success: actionResult.success,
+        result: actionResult.result,
+        error: actionResult.error,
+      },
+      timestamp: actionResult.timestamp,
+    });
+  }
+
+  // Collect from inbox (inter-agent messages)
+  const inbox = engine.getComponent<InboxComponent>(entityId, 'Inbox');
+  if (inbox && inbox.messages.length > 0) {
+    for (const msg of inbox.messages) {
+      observations.push({
+        source: `message:${msg.from}`,
+        data: { content: msg.content, metadata: msg.metadata },
+        timestamp: msg.timestamp,
+      });
+    }
+    // Clear inbox after reading
+    engine.setComponent(entityId, 'Inbox', { messages: [] } as unknown as Record<string, unknown>);
+  }
+
+  // Get tick number from existing metadata
+  const tick = engine.getComponent(entityId, 'TickMetadata');
+  const tickNumber = tick ? (tick as Record<string, unknown>).tickNumber as number : 0;
+
+  const observation: ObservationComponent = { observations, tick: tickNumber };
+  engine.setComponent(entityId, 'Observation', observation as unknown as Record<string, unknown>);
+
+  logger.debug({ entityId, observationCount: observations.length }, 'ObserveSystem: collected observations');
+}
+
+export default createObserveSystem;

--- a/src/systems/orient.ts
+++ b/src/systems/orient.ts
@@ -1,0 +1,177 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System, EntityId } from '../ecs/types.js';
+import type {
+  ObservationComponent,
+  WorldModelComponent,
+  ExperienceComponent,
+  IdentityComponent,
+  OrientationComponent,
+  AttentionFilterComponent,
+  ActionOption,
+} from '../core/components.js';
+
+/**
+ * OrientSystem: The schwerpunkt of the OODA loop.
+ * Cross-references observations against world model, detects model violations,
+ * updates the world model, and produces an OrientationComponent with
+ * situation frame, novelty score, attention shifts, and implicit action options.
+ */
+export function createOrientSystem(engine: Engine): System {
+  return {
+    name: 'OrientSystem',
+    version: '1.0.0',
+    type: 'core',
+    description: 'Destructures and reconstructs mental models from observations — the key OODA phase',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'ooda:orient') {
+        await orient(engine, event.entityId);
+      }
+    },
+  };
+}
+
+export async function orient(engine: Engine, entityId: EntityId): Promise<void> {
+  const logger = engine.getLogger();
+  const provider = engine.getProvider();
+
+  const observation = engine.getComponent<ObservationComponent>(entityId, 'Observation');
+  if (!observation || observation.observations.length === 0) {
+    // No observations — produce low-novelty orientation
+    engine.setComponent(entityId, 'Orientation', {
+      situationFrame: 'No new observations.',
+      novelty: 0,
+      attentionShift: [],
+      implicitOptions: [],
+      tick: observation?.tick ?? 0,
+    } as unknown as Record<string, unknown>);
+    return;
+  }
+
+  const worldModel = engine.getComponent<WorldModelComponent>(entityId, 'WorldModel') ?? {
+    beliefs: {},
+    lastUpdated: 0,
+    updateCount: 0,
+  };
+  const experience = engine.getComponent<ExperienceComponent>(entityId, 'Experience');
+  const identity = engine.getComponent<IdentityComponent>(entityId, 'Identity');
+
+  // Build orientation prompt
+  const systemPrompt = `You are the Orientation phase of a Boyd OODA loop. Your task:
+1. Compare new observations against the current world model (beliefs)
+2. Detect model violations — observations that contradict current beliefs
+3. Assess novelty (0.0 = routine, 1.0 = completely unexpected)
+4. Suggest attention priorities for the next observation cycle
+5. Surface implicit action options based on the situation
+
+Respond with valid JSON only, matching this schema:
+{
+  "situationFrame": "string — your interpretation of the current situation",
+  "novelty": number (0-1),
+  "beliefUpdates": { "key": "value" } | null,
+  "attentionShift": ["sensor types or focus areas to prioritize"],
+  "implicitOptions": [{ "action": "string", "confidence": number (0-1), "rationale": "string" }]
+}`;
+
+  const userContent = JSON.stringify({
+    observations: observation.observations,
+    currentBeliefs: worldModel.beliefs,
+    recentExperience: experience?.recent?.slice(0, 5) ?? [],
+    identity: identity ? { role: identity.role, goals: identity.coreGoals } : null,
+  });
+
+  try {
+    const response = await provider.generate([
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userContent },
+    ]);
+
+    const parsed = parseOrientationResponse(response.content);
+
+    // Update world model if belief updates are present
+    if (parsed.beliefUpdates && Object.keys(parsed.beliefUpdates).length > 0) {
+      const updatedBeliefs = { ...worldModel.beliefs, ...parsed.beliefUpdates };
+      engine.setComponent(entityId, 'WorldModel', {
+        beliefs: updatedBeliefs,
+        lastUpdated: Date.now(),
+        updateCount: worldModel.updateCount + 1,
+      } as unknown as Record<string, unknown>);
+    }
+
+    // Update attention filter for next Observe cycle (Boyd feedback)
+    if (parsed.attentionShift.length > 0) {
+      const currentFilter = engine.getComponent<AttentionFilterComponent>(entityId, 'AttentionFilter');
+      engine.setComponent(entityId, 'AttentionFilter', {
+        priorities: parsed.attentionShift,
+        activeSensors: currentFilter?.activeSensors ?? [],
+      } as unknown as Record<string, unknown>);
+    }
+
+    // Write orientation
+    const orientation: OrientationComponent = {
+      situationFrame: parsed.situationFrame,
+      novelty: parsed.novelty,
+      attentionShift: parsed.attentionShift,
+      implicitOptions: parsed.implicitOptions,
+      tick: observation.tick,
+    };
+    engine.setComponent(entityId, 'Orientation', orientation as unknown as Record<string, unknown>);
+
+    logger.debug(
+      { entityId, novelty: parsed.novelty, options: parsed.implicitOptions.length },
+      'OrientSystem: orientation complete',
+    );
+  } catch (err) {
+    logger.error({ entityId, error: err }, 'OrientSystem: failed to orient');
+    engine.setComponent(entityId, 'Orientation', {
+      situationFrame: 'Orientation failed — using fallback.',
+      novelty: 0.5,
+      attentionShift: [],
+      implicitOptions: [],
+      tick: observation.tick,
+    } as unknown as Record<string, unknown>);
+  }
+}
+
+interface ParsedOrientation {
+  situationFrame: string;
+  novelty: number;
+  beliefUpdates: Record<string, unknown> | null;
+  attentionShift: string[];
+  implicitOptions: ActionOption[];
+}
+
+function parseOrientationResponse(content: string): ParsedOrientation {
+  // Extract JSON from response (handle markdown code blocks)
+  const jsonMatch = content.match(/```(?:json)?\s*([\s\S]*?)```/) ?? [null, content];
+  const jsonStr = (jsonMatch[1] ?? content).trim();
+
+  try {
+    const parsed = JSON.parse(jsonStr);
+    return {
+      situationFrame: String(parsed.situationFrame ?? 'Unknown situation'),
+      novelty: Math.max(0, Math.min(1, Number(parsed.novelty) || 0)),
+      beliefUpdates: parsed.beliefUpdates ?? null,
+      attentionShift: Array.isArray(parsed.attentionShift) ? parsed.attentionShift.map(String) : [],
+      implicitOptions: Array.isArray(parsed.implicitOptions)
+        ? parsed.implicitOptions.map((o: Record<string, unknown>) => ({
+            action: String(o.action ?? ''),
+            confidence: Math.max(0, Math.min(1, Number(o.confidence) || 0)),
+            rationale: String(o.rationale ?? ''),
+          }))
+        : [],
+    };
+  } catch {
+    return {
+      situationFrame: content.slice(0, 200),
+      novelty: 0.3,
+      beliefUpdates: null,
+      attentionShift: [],
+      implicitOptions: [],
+    };
+  }
+}
+
+export default createOrientSystem;

--- a/src/systems/orient.ts
+++ b/src/systems/orient.ts
@@ -101,11 +101,11 @@ Respond with valid JSON only, matching this schema:
     }
 
     // Update attention filter for next Observe cycle (Boyd feedback)
+    // Sets both priorities and activeSensors so ObserveSystem filters accordingly
     if (parsed.attentionShift.length > 0) {
-      const currentFilter = engine.getComponent<AttentionFilterComponent>(entityId, 'AttentionFilter');
       engine.setComponent(entityId, 'AttentionFilter', {
         priorities: parsed.attentionShift,
-        activeSensors: currentFilter?.activeSensors ?? [],
+        activeSensors: parsed.attentionShift,
       } as unknown as Record<string, unknown>);
     }
 

--- a/src/systems/serialize.ts
+++ b/src/systems/serialize.ts
@@ -1,0 +1,85 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System, EntityId } from '../ecs/types.js';
+import { MemoryStore } from '../store/memory-store.js';
+
+/**
+ * EntitySerializationSystem: Snapshots and restores full entity state.
+ * Serializes all components on an entity to SQLite for session continuity.
+ */
+export function createEntitySerializationSystem(engine: Engine): System {
+  const memoryStore = new MemoryStore(engine.getStore().db);
+
+  return {
+    name: 'EntitySerializationSystem',
+    version: '1.0.0',
+    type: 'core',
+    description: 'Snapshots entity state for persistence and restores from snapshots on startup',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'entity:snapshot') {
+        snapshotEntity(engine, memoryStore, event.entityId);
+      } else if (event.type === 'entity:snapshot-all') {
+        snapshotAll(engine, memoryStore);
+      } else if (event.type === 'entity:restore-all') {
+        restoreAll(engine, memoryStore);
+      }
+    },
+  };
+}
+
+export function snapshotEntity(engine: Engine, memoryStore: MemoryStore, entityId: EntityId): void {
+  const logger = engine.getLogger();
+  const store = engine.getStore();
+
+  // Get all components for this entity
+  const rows = store.db
+    .prepare('SELECT name, data FROM components WHERE entity_id = ?')
+    .all(entityId) as Array<{ name: string; data: string }>;
+
+  const components: Record<string, unknown> = {};
+  for (const row of rows) {
+    components[row.name] = JSON.parse(row.data);
+  }
+
+  memoryStore.saveSnapshot(entityId, components);
+  logger.debug({ entityId, componentCount: rows.length }, 'EntitySerialization: snapshot saved');
+}
+
+export function snapshotAll(engine: Engine, memoryStore: MemoryStore): void {
+  const logger = engine.getLogger();
+  const store = engine.getStore();
+
+  const entities = store.db
+    .prepare('SELECT id FROM entities')
+    .all() as Array<{ id: string }>;
+
+  for (const { id } of entities) {
+    snapshotEntity(engine, memoryStore, id);
+  }
+
+  logger.info({ entityCount: entities.length }, 'EntitySerialization: all entities snapshotted');
+}
+
+export function restoreAll(engine: Engine, memoryStore: MemoryStore): void {
+  const logger = engine.getLogger();
+
+  const snapshots = memoryStore.getAllLatestSnapshots();
+
+  for (const snapshot of snapshots) {
+    // Create entity if it doesn't exist
+    if (!engine.entityExists(snapshot.entityId)) {
+      engine.createEntity(snapshot.entityId);
+    }
+
+    // Restore all components
+    for (const [name, data] of Object.entries(snapshot.components)) {
+      engine.setComponent(snapshot.entityId, name, data as Record<string, unknown>);
+    }
+  }
+
+  logger.info({ entityCount: snapshots.length }, 'EntitySerialization: entities restored from snapshots');
+}
+
+export default createEntitySerializationSystem;

--- a/src/systems/skills.ts
+++ b/src/systems/skills.ts
@@ -155,7 +155,7 @@ export function createSkillImprovementSystem(engine: Engine): System {
         memoryStore.updateProceduralStats(skillId, success, reward);
 
         // Check if skill needs re-synthesis
-        const skill = memoryStore.getProceduralByName(event.entityId, skillId);
+        const skill = memoryStore.getProceduralById(skillId);
         if (skill && skill.failureCount >= FAILURE_RESYNTHESIZE_THRESHOLD) {
           engine.emit({
             type: 'skill:needs-resynth',

--- a/src/systems/skills.ts
+++ b/src/systems/skills.ts
@@ -1,0 +1,173 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System, EntityId } from '../ecs/types.js';
+import type {
+  ActionResultComponent,
+  EpisodicMemoryComponent,
+  ProceduralMemoryComponent,
+  SkillRecord,
+  ToolStep,
+} from '../core/components.js';
+import { MemoryStore } from '../store/memory-store.js';
+import { uniqueId } from '../util/hash.js';
+
+const SKILL_CREATION_MIN_STEPS = 2;
+const FAILURE_RESYNTHESIZE_THRESHOLD = 3;
+const EMA_ALPHA = 0.3;
+
+/**
+ * SkillCreationSystem: After a successful multi-step action sequence,
+ * synthesizes a reusable skill from the episodic memory buffer.
+ * Skills are per-entity — different agents learn different skills.
+ */
+export function createSkillCreationSystem(engine: Engine): System {
+  const memoryStore = new MemoryStore(engine.getStore().db);
+
+  return {
+    name: 'SkillCreationSystem',
+    version: '1.0.0',
+    type: 'system',
+    description: 'Synthesizes reusable skills from successful multi-step action sequences',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'ooda:tick-complete') {
+        await maybeCreateSkill(engine, memoryStore, event.entityId);
+      }
+    },
+  };
+}
+
+async function maybeCreateSkill(engine: Engine, memoryStore: MemoryStore, entityId: EntityId): Promise<void> {
+  const logger = engine.getLogger();
+
+  const actionResult = engine.getComponent<ActionResultComponent>(entityId, 'ActionResult');
+  if (!actionResult?.success) return;
+
+  const episodic = engine.getComponent<EpisodicMemoryComponent>(entityId, 'EpisodicMemory');
+  if (!episodic || episodic.episodes.length < SKILL_CREATION_MIN_STEPS) return;
+
+  // Look at the recent episode sequence for a multi-step success pattern
+  const recentEpisodes = episodic.episodes.slice(-SKILL_CREATION_MIN_STEPS);
+  const allSuccessful = recentEpisodes.every((ep) => {
+    const result = ep.result as Record<string, unknown> | null;
+    return result && result.executed;
+  });
+
+  if (!allSuccessful) return;
+
+  const provider = engine.getProvider();
+
+  const systemPrompt = `You are a skill synthesizer. Given a sequence of successful action episodes, extract a reusable skill template.
+
+Respond with valid JSON:
+{
+  "name": "string — short skill name",
+  "description": "string — what the skill does",
+  "preconditions": ["conditions that must be true to use this skill"],
+  "toolSequence": [{"toolName": "string", "parameters": {}, "description": "string"}],
+  "successCriteria": "string — how to verify the skill worked",
+  "failureModes": ["possible failure modes"]
+}`;
+
+  try {
+    const response = await provider.generate([
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: JSON.stringify({ episodes: recentEpisodes }) },
+    ]);
+
+    const jsonMatch = response.content.match(/```(?:json)?\s*([\s\S]*?)```/) ?? [null, response.content];
+    const parsed = JSON.parse((jsonMatch[1] ?? response.content).trim());
+
+    const skill: SkillRecord = {
+      id: uniqueId(),
+      name: String(parsed.name ?? 'unnamed-skill'),
+      description: String(parsed.description ?? ''),
+      preconditions: Array.isArray(parsed.preconditions) ? parsed.preconditions.map(String) : [],
+      toolSequence: Array.isArray(parsed.toolSequence)
+        ? parsed.toolSequence.map((s: Record<string, unknown>) => ({
+            toolName: String(s.toolName ?? ''),
+            parameters: (s.parameters ?? {}) as Record<string, unknown>,
+            description: String(s.description ?? ''),
+          }))
+        : [],
+      successCriteria: String(parsed.successCriteria ?? ''),
+      failureModes: Array.isArray(parsed.failureModes) ? parsed.failureModes.map(String) : [],
+      successCount: 1,
+      failureCount: 0,
+      avgReward: 1.0,
+      source: 'learned',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    // Store in procedural memory table
+    memoryStore.addProcedural(
+      entityId,
+      skill.id,
+      skill.name,
+      skill.description,
+      skill.toolSequence as unknown as ToolStep[],
+      skill.source,
+    );
+
+    // Update component
+    const procedural = engine.getComponent<ProceduralMemoryComponent>(entityId, 'ProceduralMemory') ?? { skills: [] };
+    procedural.skills.push(skill);
+    engine.setComponent(entityId, 'ProceduralMemory', procedural as unknown as Record<string, unknown>);
+
+    engine.emit({
+      type: 'skill:created',
+      entityId,
+      data: { skillId: skill.id, skillName: skill.name },
+      source: 'SkillCreationSystem',
+      timestamp: Date.now(),
+    });
+
+    logger.info({ entityId, skillName: skill.name }, 'SkillCreation: new skill synthesized');
+  } catch (err) {
+    logger.debug({ entityId, error: err }, 'SkillCreation: skill synthesis failed');
+  }
+}
+
+/**
+ * SkillImprovementSystem: Updates skill stats when skills are used.
+ * Flags skills for re-synthesis when failure count exceeds threshold.
+ */
+export function createSkillImprovementSystem(engine: Engine): System {
+  const memoryStore = new MemoryStore(engine.getStore().db);
+
+  return {
+    name: 'SkillImprovementSystem',
+    version: '1.0.0',
+    type: 'system',
+    description: 'Tracks skill success/failure rates and flags degrading skills for re-synthesis',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type === 'skill:used') {
+        const { skillId, success, reward } = event.data as {
+          skillId: string;
+          success: boolean;
+          reward: number;
+        };
+        memoryStore.updateProceduralStats(skillId, success, reward);
+
+        // Check if skill needs re-synthesis
+        const skill = memoryStore.getProceduralByName(event.entityId, skillId);
+        if (skill && skill.failureCount >= FAILURE_RESYNTHESIZE_THRESHOLD) {
+          engine.emit({
+            type: 'skill:needs-resynth',
+            entityId: event.entityId,
+            data: { skillId: skill.id, skillName: skill.skillName, failures: skill.failureCount },
+            source: 'SkillImprovementSystem',
+            timestamp: Date.now(),
+          });
+        }
+      }
+    },
+  };
+}
+
+export default createSkillCreationSystem;

--- a/src/systems/spawn.ts
+++ b/src/systems/spawn.ts
@@ -1,0 +1,80 @@
+import type { Engine } from '../ecs/engine.js';
+import type { System } from '../ecs/types.js';
+import type { ChildAgentsComponent, ParentAgentComponent } from '../core/components.js';
+import { uniqueId } from '../util/hash.js';
+
+/**
+ * AgentSpawnSystem: Creates sub-agent entities when a decision is to delegate.
+ * Parent passes filtered components to the child. Child runs its own OODA loop.
+ */
+export function createAgentSpawnSystem(engine: Engine): System {
+  return {
+    name: 'AgentSpawnSystem',
+    version: '1.0.0',
+    type: 'core',
+    description: 'Spawns sub-agent entities with inherited components for task delegation',
+
+    init() {},
+
+    async handleEvent(event) {
+      if (event.type !== 'agent:spawn') return;
+
+      const logger = engine.getLogger();
+      const parentId = event.entityId;
+      const data = event.data as {
+        role?: string;
+        systemPrompt?: string;
+        goals?: string[];
+        components?: Record<string, Record<string, unknown>>;
+      };
+
+      const childId = uniqueId();
+      engine.createEntity(childId);
+
+      // Mark as OODA agent
+      engine.addComponent(childId, 'OodaAgent', { active: true });
+
+      // Set identity
+      engine.addComponent(childId, 'Identity', {
+        role: data.role ?? 'sub-agent',
+        systemPrompt: data.systemPrompt ?? '',
+        coreGoals: data.goals ?? [],
+        learnedPreferences: {},
+      });
+
+      // Initialize empty OODA components
+      engine.addComponent(childId, 'WorldModel', { beliefs: {}, lastUpdated: 0, updateCount: 0 });
+      engine.addComponent(childId, 'Inbox', { messages: [] });
+      engine.addComponent(childId, 'Outbox', { messages: [] });
+
+      // Copy any additional components from parent
+      if (data.components) {
+        for (const [name, componentData] of Object.entries(data.components)) {
+          engine.addComponent(childId, name, componentData);
+        }
+      }
+
+      // Set parent reference on child
+      engine.addComponent(childId, 'ParentAgent', {
+        parentEntityId: parentId,
+      } as unknown as Record<string, unknown>);
+
+      // Track child on parent
+      const children = engine.getComponent<ChildAgentsComponent>(parentId, 'ChildAgents') ?? { childEntityIds: [] };
+      children.childEntityIds.push(childId);
+      engine.setComponent(parentId, 'ChildAgents', children as unknown as Record<string, unknown>);
+
+      engine.emit({
+        type: 'agent:spawned',
+        entityId: childId,
+        data: { parentId, role: data.role },
+        source: 'AgentSpawnSystem',
+        timestamp: Date.now(),
+      });
+
+      logger.info({ parentId, childId, role: data.role }, 'AgentSpawn: sub-agent created');
+    },
+  };
+}
+
+export default createAgentSpawnSystem;

--- a/tests/core/boyd-correctness.test.ts
+++ b/tests/core/boyd-correctness.test.ts
@@ -32,13 +32,12 @@ describe('Boyd Correctness: Implicit Guidance Loop', () => {
   });
 
   it('Orient attentionShift changes what ObserveSystem filters on the next tick', async () => {
-    // Tick 1: Orient says to focus on 'network' sensors only
     let callCount = 0;
     const provider: ModelProvider = {
       async generate(): Promise<ModelResponse> {
         callCount++;
         if (callCount === 1) {
-          // Tick 1 orient response: shift attention to 'network'
+          // Orient response: shift attention to 'network'
           return {
             content: JSON.stringify({
               situationFrame: 'Network anomaly detected',
@@ -49,24 +48,7 @@ describe('Boyd Correctness: Implicit Guidance Loop', () => {
             }),
           };
         }
-        if (callCount === 2) {
-          // Tick 1 decide response (deliberate due to high novelty)
-          return {
-            content: JSON.stringify({
-              selectedAction: 'investigate-network',
-              rationale: 'Need to check network',
-            }),
-          };
-        }
-        // Tick 2 responses
-        return {
-          content: JSON.stringify({
-            situationFrame: 'Investigating',
-            novelty: 0.2,
-            attentionShift: [],
-            implicitOptions: [{ action: 'continue', confidence: 0.9, rationale: 'Normal' }],
-          }),
-        };
+        return { content: JSON.stringify({ selectedAction: 'investigate', rationale: 'check' }) };
       },
     };
 
@@ -77,56 +59,42 @@ describe('Boyd Correctness: Implicit Guidance Loop', () => {
     engine.addComponent(entityId, 'OodaAgent', { active: true });
     engine.addComponent(entityId, 'WorldModel', { beliefs: {}, lastUpdated: 0, updateCount: 0 });
 
-    // Add two sensors: 'network' and 'disk'
-    // We can't attach multiple sensors to same entity with same component name,
-    // so we'll verify via AttentionFilter behavior
+    // Attach a 'network' sensor to the entity
     engine.addComponent(entityId, 'Sensor', {
       sensorType: 'network',
       active: true,
       config: { interface: 'eth0' },
     });
 
-    // Add an initial observation to trigger orient
+    // Add initial observation to trigger orient
     engine.addComponent(entityId, 'Observation', {
       observations: [{ source: 'boot', data: {}, timestamp: Date.now() }],
       tick: 0,
     });
 
-    // --- Tick 1: Orient ---
+    // --- Orient sets AttentionFilter (both priorities AND activeSensors) ---
     await orient(engine, entityId);
 
-    // Verify AttentionFilter was set by Orient
     const filter = engine.getComponent(entityId, 'AttentionFilter') as Record<string, unknown>;
     expect(filter).not.toBeNull();
     expect(filter.priorities).toEqual(['network']);
+    // Orient now sets activeSensors too — this is the Boyd feedback arrow
+    expect(filter.activeSensors).toEqual(['network']);
 
-    // --- Tick 2: Observe with the new attention filter ---
-    // First, set up AttentionFilter to only allow 'disk' sensors (to test filtering)
-    engine.setComponent(entityId, 'AttentionFilter', {
-      priorities: ['disk'],
-      activeSensors: ['disk'], // only 'disk' sensors active
-    });
-
+    // --- Observe uses the Orient-produced filter without manual overwrite ---
     await observe(engine, entityId);
 
-    // The 'network' sensor should be filtered OUT because activeSensors is ['disk']
     const obs = engine.getComponent(entityId, 'Observation') as Record<string, unknown>;
     const observations = obs.observations as Array<Record<string, unknown>>;
+
+    // 'network' sensor should come through because activeSensors includes 'network'
     const networkObs = observations.filter((o) => o.source === 'network');
-    expect(networkObs.length).toBe(0);
+    expect(networkObs.length).toBe(1);
 
-    // Now switch back to allowing 'network' and verify it comes through
-    engine.setComponent(entityId, 'AttentionFilter', {
-      priorities: ['network'],
-      activeSensors: ['network'],
-    });
-
-    await observe(engine, entityId);
-
-    const obs2 = engine.getComponent(entityId, 'Observation') as Record<string, unknown>;
-    const observations2 = obs2.observations as Array<Record<string, unknown>>;
-    const networkObs2 = observations2.filter((o) => o.source === 'network');
-    expect(networkObs2.length).toBe(1);
+    // If there were a 'disk' sensor, it would be filtered out —
+    // verify by checking no 'disk' observations exist
+    const diskObs = observations.filter((o) => o.source === 'disk');
+    expect(diskObs.length).toBe(0);
   });
 
   it('runs a complete 2-tick OODA loop with Boyd feedback', async () => {
@@ -134,7 +102,6 @@ describe('Boyd Correctness: Implicit Guidance Loop', () => {
     const provider: ModelProvider = {
       async generate(): Promise<ModelResponse> {
         orientCallCount++;
-        // Always return valid orientation/decision responses
         return {
           content: JSON.stringify({
             situationFrame: `Tick ${orientCallCount}`,
@@ -177,5 +144,53 @@ describe('Boyd Correctness: Implicit Guidance Loop', () => {
     // Verify observation collected the previous action result
     const obs = engine.getComponent(entityId, 'Observation') as Record<string, unknown>;
     expect(obs).not.toBeNull();
+  });
+
+  it('worldModelUpdated reflects actual WorldModel changes, not just novelty', async () => {
+    let callCount = 0;
+    const provider: ModelProvider = {
+      async generate(): Promise<ModelResponse> {
+        callCount++;
+        if (callCount === 1) {
+          // High novelty WITH belief updates → worldModelUpdated should be true
+          return {
+            content: JSON.stringify({
+              situationFrame: 'New info',
+              novelty: 0.9,
+              beliefUpdates: { discovered: 'something' },
+              attentionShift: [],
+              implicitOptions: [{ action: 'act', confidence: 0.8, rationale: 'reason' }],
+            }),
+          };
+        }
+        // Decide response
+        return { content: JSON.stringify({ selectedAction: 'act', rationale: 'ok' }) };
+      },
+    };
+
+    store = new Store(':memory:');
+    engine = new Engine(store, provider, mockLogger());
+
+    const entityId = engine.createEntity('agent');
+    engine.addComponent(entityId, 'OodaAgent', { active: true });
+    engine.addComponent(entityId, 'WorldModel', { beliefs: {}, lastUpdated: 0, updateCount: 0 });
+    // Seed an action result so Observe produces observations for Orient to process
+    engine.addComponent(entityId, 'ActionResult', {
+      action: 'init', success: true, result: { boot: true }, tick: 0, timestamp: Date.now(),
+    });
+
+    const systems: OodaSystemRef = {
+      observe: (id) => observe(engine, id),
+      orient: (id) => orient(engine, id),
+      decide: (id) => decide(engine, id),
+      act: (id) => act(engine, id),
+    };
+
+    const meta = await runOodaTick(engine, entityId, systems, 1);
+    // worldModelUpdated is based on WorldModel.updateCount change, not novelty threshold
+    expect(meta.worldModelUpdated).toBe(true);
+
+    const wm = engine.getComponent(entityId, 'WorldModel') as Record<string, unknown>;
+    expect((wm.beliefs as Record<string, unknown>).discovered).toBe('something');
   });
 });

--- a/tests/core/boyd-correctness.test.ts
+++ b/tests/core/boyd-correctness.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Engine } from '../../src/ecs/engine.js';
+import { Store } from '../../src/store/db.js';
+import type { ModelProvider, ModelResponse } from '../../src/model/types.js';
+import type { Logger } from '../../src/util/logger.js';
+import { observe } from '../../src/systems/observe.js';
+import { orient } from '../../src/systems/orient.js';
+import { decide } from '../../src/systems/decide.js';
+import { act } from '../../src/systems/act.js';
+import { runOodaTick } from '../../src/core/tick.js';
+import type { OodaSystemRef } from '../../src/core/tick.js';
+
+function mockLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+    level: 'info',
+  } as unknown as Logger;
+}
+
+describe('Boyd Correctness: Implicit Guidance Loop', () => {
+  let store: Store;
+  let engine: Engine;
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('Orient attentionShift changes what ObserveSystem filters on the next tick', async () => {
+    // Tick 1: Orient says to focus on 'network' sensors only
+    let callCount = 0;
+    const provider: ModelProvider = {
+      async generate(): Promise<ModelResponse> {
+        callCount++;
+        if (callCount === 1) {
+          // Tick 1 orient response: shift attention to 'network'
+          return {
+            content: JSON.stringify({
+              situationFrame: 'Network anomaly detected',
+              novelty: 0.7,
+              beliefUpdates: { networkStatus: 'anomalous' },
+              attentionShift: ['network'],
+              implicitOptions: [{ action: 'investigate-network', confidence: 0.8, rationale: 'Anomaly' }],
+            }),
+          };
+        }
+        if (callCount === 2) {
+          // Tick 1 decide response (deliberate due to high novelty)
+          return {
+            content: JSON.stringify({
+              selectedAction: 'investigate-network',
+              rationale: 'Need to check network',
+            }),
+          };
+        }
+        // Tick 2 responses
+        return {
+          content: JSON.stringify({
+            situationFrame: 'Investigating',
+            novelty: 0.2,
+            attentionShift: [],
+            implicitOptions: [{ action: 'continue', confidence: 0.9, rationale: 'Normal' }],
+          }),
+        };
+      },
+    };
+
+    store = new Store(':memory:');
+    engine = new Engine(store, provider, mockLogger());
+
+    const entityId = engine.createEntity('agent');
+    engine.addComponent(entityId, 'OodaAgent', { active: true });
+    engine.addComponent(entityId, 'WorldModel', { beliefs: {}, lastUpdated: 0, updateCount: 0 });
+
+    // Add two sensors: 'network' and 'disk'
+    // We can't attach multiple sensors to same entity with same component name,
+    // so we'll verify via AttentionFilter behavior
+    engine.addComponent(entityId, 'Sensor', {
+      sensorType: 'network',
+      active: true,
+      config: { interface: 'eth0' },
+    });
+
+    // Add an initial observation to trigger orient
+    engine.addComponent(entityId, 'Observation', {
+      observations: [{ source: 'boot', data: {}, timestamp: Date.now() }],
+      tick: 0,
+    });
+
+    // --- Tick 1: Orient ---
+    await orient(engine, entityId);
+
+    // Verify AttentionFilter was set by Orient
+    const filter = engine.getComponent(entityId, 'AttentionFilter') as Record<string, unknown>;
+    expect(filter).not.toBeNull();
+    expect(filter.priorities).toEqual(['network']);
+
+    // --- Tick 2: Observe with the new attention filter ---
+    // First, set up AttentionFilter to only allow 'disk' sensors (to test filtering)
+    engine.setComponent(entityId, 'AttentionFilter', {
+      priorities: ['disk'],
+      activeSensors: ['disk'], // only 'disk' sensors active
+    });
+
+    await observe(engine, entityId);
+
+    // The 'network' sensor should be filtered OUT because activeSensors is ['disk']
+    const obs = engine.getComponent(entityId, 'Observation') as Record<string, unknown>;
+    const observations = obs.observations as Array<Record<string, unknown>>;
+    const networkObs = observations.filter((o) => o.source === 'network');
+    expect(networkObs.length).toBe(0);
+
+    // Now switch back to allowing 'network' and verify it comes through
+    engine.setComponent(entityId, 'AttentionFilter', {
+      priorities: ['network'],
+      activeSensors: ['network'],
+    });
+
+    await observe(engine, entityId);
+
+    const obs2 = engine.getComponent(entityId, 'Observation') as Record<string, unknown>;
+    const observations2 = obs2.observations as Array<Record<string, unknown>>;
+    const networkObs2 = observations2.filter((o) => o.source === 'network');
+    expect(networkObs2.length).toBe(1);
+  });
+
+  it('runs a complete 2-tick OODA loop with Boyd feedback', async () => {
+    let orientCallCount = 0;
+    const provider: ModelProvider = {
+      async generate(): Promise<ModelResponse> {
+        orientCallCount++;
+        // Always return valid orientation/decision responses
+        return {
+          content: JSON.stringify({
+            situationFrame: `Tick ${orientCallCount}`,
+            novelty: 0.1,
+            attentionShift: [],
+            implicitOptions: [{ action: 'monitor', confidence: 0.9, rationale: 'Routine' }],
+            selectedAction: 'monitor',
+            rationale: 'Routine monitoring',
+          }),
+        };
+      },
+    };
+
+    store = new Store(':memory:');
+    engine = new Engine(store, provider, mockLogger());
+
+    const entityId = engine.createEntity('agent');
+    engine.addComponent(entityId, 'OodaAgent', { active: true });
+    engine.addComponent(entityId, 'WorldModel', { beliefs: {}, lastUpdated: 0, updateCount: 0 });
+
+    const systems: OodaSystemRef = {
+      observe: (id) => observe(engine, id),
+      orient: (id) => orient(engine, id),
+      decide: (id) => decide(engine, id),
+      act: (id) => act(engine, id),
+    };
+
+    // Tick 1
+    const meta1 = await runOodaTick(engine, entityId, systems, 1);
+    expect(meta1.tickNumber).toBe(1);
+
+    // After tick 1, ActionResult should exist
+    const result1 = engine.getComponent(entityId, 'ActionResult');
+    expect(result1).not.toBeNull();
+
+    // Tick 2 — ActionResult from tick 1 should flow into Observe
+    const meta2 = await runOodaTick(engine, entityId, systems, 2);
+    expect(meta2.tickNumber).toBe(2);
+
+    // Verify observation collected the previous action result
+    const obs = engine.getComponent(entityId, 'Observation') as Record<string, unknown>;
+    expect(obs).not.toBeNull();
+  });
+});

--- a/tests/core/tick.test.ts
+++ b/tests/core/tick.test.ts
@@ -95,19 +95,18 @@ describe('OODA Tick Orchestrator', () => {
     expect(handler.mock.calls[0][0].data.tickNumber).toBe(1);
   });
 
-  it('detects worldmodel update from high novelty orientation', async () => {
+  it('detects worldmodel update from WorldModel.updateCount change', async () => {
     const entityId = engine.createEntity('agent-1');
+    engine.addComponent(entityId, 'WorldModel', { beliefs: {}, lastUpdated: 0, updateCount: 0 });
 
     const systems: OodaSystemRef = {
       observe: vi.fn(async () => {}),
       orient: vi.fn(async () => {
-        // Simulate orient setting high novelty
-        engine.setComponent(entityId, 'Orientation', {
-          situationFrame: 'novel',
-          novelty: 0.9,
-          attentionShift: [],
-          implicitOptions: [],
-          tick: 1,
+        // Simulate orient updating the world model (incrementing updateCount)
+        engine.setComponent(entityId, 'WorldModel', {
+          beliefs: { updated: true },
+          lastUpdated: Date.now(),
+          updateCount: 1,
         });
       }),
       decide: vi.fn(async () => {}),
@@ -116,6 +115,21 @@ describe('OODA Tick Orchestrator', () => {
 
     const meta = await runOodaTick(engine, entityId, systems, 1);
     expect(meta.worldModelUpdated).toBe(true);
+  });
+
+  it('worldModelUpdated is false when WorldModel unchanged', async () => {
+    const entityId = engine.createEntity('agent-1');
+    engine.addComponent(entityId, 'WorldModel', { beliefs: {}, lastUpdated: 0, updateCount: 5 });
+
+    const systems: OodaSystemRef = {
+      observe: vi.fn(async () => {}),
+      orient: vi.fn(async () => {}), // does not update WorldModel
+      decide: vi.fn(async () => {}),
+      act: vi.fn(async () => {}),
+    };
+
+    const meta = await runOodaTick(engine, entityId, systems, 1);
+    expect(meta.worldModelUpdated).toBe(false);
   });
 
   it('runOodaTickAll processes all OodaAgent entities', async () => {

--- a/tests/core/tick.test.ts
+++ b/tests/core/tick.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Engine } from '../../src/ecs/engine.js';
+import { Store } from '../../src/store/db.js';
+import type { ModelProvider, ModelResponse } from '../../src/model/types.js';
+import type { Logger } from '../../src/util/logger.js';
+import { runOodaTick, runOodaTickAll } from '../../src/core/tick.js';
+import type { OodaSystemRef } from '../../src/core/tick.js';
+
+function mockProvider(): ModelProvider {
+  return {
+    async generate(): Promise<ModelResponse> {
+      return { content: 'mock' };
+    },
+  };
+}
+
+function mockLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+    level: 'info',
+  } as unknown as Logger;
+}
+
+describe('OODA Tick Orchestrator', () => {
+  let store: Store;
+  let engine: Engine;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+    engine = new Engine(store, mockProvider(), mockLogger());
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('runs all four phases in order', async () => {
+    const entityId = engine.createEntity('agent-1');
+    engine.addComponent(entityId, 'OodaAgent', { active: true });
+
+    const order: string[] = [];
+    const systems: OodaSystemRef = {
+      observe: vi.fn(async () => { order.push('observe'); }),
+      orient: vi.fn(async () => { order.push('orient'); }),
+      decide: vi.fn(async () => { order.push('decide'); }),
+      act: vi.fn(async () => { order.push('act'); }),
+    };
+
+    const meta = await runOodaTick(engine, entityId, systems, 1);
+
+    expect(order).toEqual(['observe', 'orient', 'decide', 'act']);
+    expect(meta.tickNumber).toBe(1);
+    expect(meta.phaseDurations.observe).toBeGreaterThanOrEqual(0);
+    expect(meta.phaseDurations.orient).toBeGreaterThanOrEqual(0);
+    expect(meta.phaseDurations.decide).toBeGreaterThanOrEqual(0);
+    expect(meta.phaseDurations.act).toBeGreaterThanOrEqual(0);
+  });
+
+  it('stores TickMetadata component on entity', async () => {
+    const entityId = engine.createEntity('agent-1');
+    const systems: OodaSystemRef = {
+      observe: vi.fn(async () => {}),
+      orient: vi.fn(async () => {}),
+      decide: vi.fn(async () => {}),
+      act: vi.fn(async () => {}),
+    };
+
+    await runOodaTick(engine, entityId, systems, 5);
+
+    const meta = engine.getComponent(entityId, 'TickMetadata');
+    expect(meta).not.toBeNull();
+    expect((meta as Record<string, unknown>).tickNumber).toBe(5);
+  });
+
+  it('emits ooda:tick-complete event', async () => {
+    const entityId = engine.createEntity('agent-1');
+    const handler = vi.fn();
+    engine.on('ooda:tick-complete', handler);
+
+    const systems: OodaSystemRef = {
+      observe: vi.fn(async () => {}),
+      orient: vi.fn(async () => {}),
+      decide: vi.fn(async () => {}),
+      act: vi.fn(async () => {}),
+    };
+
+    await runOodaTick(engine, entityId, systems, 1);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][0].data.tickNumber).toBe(1);
+  });
+
+  it('detects worldmodel update from high novelty orientation', async () => {
+    const entityId = engine.createEntity('agent-1');
+
+    const systems: OodaSystemRef = {
+      observe: vi.fn(async () => {}),
+      orient: vi.fn(async () => {
+        // Simulate orient setting high novelty
+        engine.setComponent(entityId, 'Orientation', {
+          situationFrame: 'novel',
+          novelty: 0.9,
+          attentionShift: [],
+          implicitOptions: [],
+          tick: 1,
+        });
+      }),
+      decide: vi.fn(async () => {}),
+      act: vi.fn(async () => {}),
+    };
+
+    const meta = await runOodaTick(engine, entityId, systems, 1);
+    expect(meta.worldModelUpdated).toBe(true);
+  });
+
+  it('runOodaTickAll processes all OodaAgent entities', async () => {
+    engine.createEntity('agent-1');
+    engine.addComponent('agent-1', 'OodaAgent', { active: true });
+    engine.createEntity('agent-2');
+    engine.addComponent('agent-2', 'OodaAgent', { active: true });
+    engine.createEntity('non-agent');
+
+    const systems: OodaSystemRef = {
+      observe: vi.fn(async () => {}),
+      orient: vi.fn(async () => {}),
+      decide: vi.fn(async () => {}),
+      act: vi.fn(async () => {}),
+    };
+
+    const results = await runOodaTickAll(engine, systems, 1);
+    expect(results.size).toBe(2);
+    expect(results.has('agent-1')).toBe(true);
+    expect(results.has('agent-2')).toBe(true);
+    expect(systems.observe).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/model/router.test.ts
+++ b/tests/model/router.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ModelProviderRouter } from '../../src/model/router.js';
+import type { ModelProvider, ModelResponse } from '../../src/model/types.js';
+
+function createMockProvider(name: string, shouldFail = false): ModelProvider {
+  return {
+    async generate(): Promise<ModelResponse> {
+      if (shouldFail) throw new Error(`${name} failed`);
+      return { content: `response from ${name}` };
+    },
+    async embed(text: string): Promise<number[]> {
+      return [1, 2, 3];
+    },
+  };
+}
+
+describe('ModelProviderRouter', () => {
+  it('routes to primary provider by default', async () => {
+    const primary = createMockProvider('primary');
+    const fallback = createMockProvider('fallback');
+    const router = new ModelProviderRouter(primary, fallback);
+
+    const result = await router.generate([{ role: 'user', content: 'test' }]);
+    expect(result.content).toBe('response from primary');
+  });
+
+  it('falls back to secondary on primary failure', async () => {
+    const primary = createMockProvider('primary', true);
+    const fallback = createMockProvider('fallback');
+    const router = new ModelProviderRouter(primary, fallback);
+
+    const result = await router.generate([{ role: 'user', content: 'test' }]);
+    expect(result.content).toBe('response from fallback');
+  });
+
+  it('tracks request stats', async () => {
+    const primary = createMockProvider('primary');
+    const fallback = createMockProvider('fallback');
+    const router = new ModelProviderRouter(primary, fallback);
+
+    await router.generate([{ role: 'user', content: 'test' }]);
+    await router.generate([{ role: 'user', content: 'test2' }]);
+
+    const stats = router.getStats();
+    expect(stats.primary.requests).toBe(2);
+    expect(stats.primary.errors).toBe(0);
+  });
+
+  it('tracks error rate', async () => {
+    const primary = createMockProvider('primary', true);
+    const fallback = createMockProvider('fallback');
+    const router = new ModelProviderRouter(primary, fallback);
+
+    await router.generate([{ role: 'user', content: 'test' }]);
+
+    expect(router.getErrorRate('primary')).toBe(1); // 1 error / 1 request
+    expect(router.getStats().primary.requests).toBe(1);
+    expect(router.getStats().primary.errors).toBe(1);
+  });
+
+  it('delegates embed to provider that supports it', async () => {
+    const primary = createMockProvider('primary');
+    const fallback = createMockProvider('fallback');
+    const router = new ModelProviderRouter(primary, fallback);
+
+    const result = await router.embed('test');
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it('throws when no provider supports embed', async () => {
+    const primary: ModelProvider = { async generate() { return { content: '' }; } };
+    const fallback: ModelProvider = { async generate() { return { content: '' }; } };
+    const router = new ModelProviderRouter(primary, fallback);
+
+    await expect(router.embed('test')).rejects.toThrow('No provider supports embed()');
+  });
+});

--- a/tests/skills/importer.test.ts
+++ b/tests/skills/importer.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { importSkillFromMarkdown } from '../../src/skills/importer.js';
+
+describe('Skill Importer', () => {
+  it('parses a full skill markdown document', () => {
+    const markdown = `# Deploy Service
+
+## Description
+Deploys a service to the production cluster.
+
+## Preconditions
+- Service is built and tested
+- Cluster is accessible
+
+## Steps
+1. Build container image
+2. Push to registry
+3. Update deployment manifest
+4. Apply to cluster
+
+## Success Criteria
+Service responds to health check within 60 seconds.
+
+## Failure Modes
+- Registry push timeout
+- Cluster unreachable
+- Health check fails
+`;
+
+    const skill = importSkillFromMarkdown(markdown);
+
+    expect(skill.name).toBe('Deploy Service');
+    expect(skill.description).toContain('Deploys a service');
+    expect(skill.preconditions).toHaveLength(2);
+    expect(skill.preconditions[0]).toBe('Service is built and tested');
+    expect(skill.toolSequence).toHaveLength(4);
+    expect(skill.toolSequence[0].description).toBe('Build container image');
+    expect(skill.successCriteria).toContain('health check');
+    expect(skill.failureModes).toHaveLength(3);
+    expect(skill.source).toBe('agentskills.io');
+    expect(skill.avgReward).toBe(0.5);
+  });
+
+  it('handles minimal markdown with just a heading', () => {
+    const markdown = `# Simple Skill\nDoes something.`;
+
+    const skill = importSkillFromMarkdown(markdown);
+    expect(skill.name).toBe('Simple Skill');
+    expect(skill.toolSequence).toHaveLength(0);
+  });
+
+  it('handles empty markdown gracefully', () => {
+    const skill = importSkillFromMarkdown('');
+    expect(skill.name).toBe('imported-skill');
+    expect(skill.source).toBe('agentskills.io');
+  });
+});

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -104,6 +104,18 @@ describe('MemoryStore', () => {
       const missing = memStore.getProceduralByName('agent-1', 'nonexistent');
       expect(missing).toBeNull();
     });
+
+    it('looks up skill by id', () => {
+      memStore.addProcedural('agent-1', 'sk-42', 'my-skill', 'A skill', [], 'learned');
+
+      const skill = memStore.getProceduralById('sk-42');
+      expect(skill).not.toBeNull();
+      expect(skill!.skillName).toBe('my-skill');
+      expect(skill!.entityId).toBe('agent-1');
+
+      const missing = memStore.getProceduralById('nonexistent');
+      expect(missing).toBeNull();
+    });
   });
 
   describe('Entity Snapshots', () => {

--- a/tests/store/memory-store.test.ts
+++ b/tests/store/memory-store.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../../src/store/migrations.js';
+import { MemoryStore } from '../../src/store/memory-store.js';
+import { serializeEmbedding } from '../../src/model/embedding.js';
+
+describe('MemoryStore', () => {
+  let db: Database.Database;
+  let memStore: MemoryStore;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    runMigrations(db);
+    memStore = new MemoryStore(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('Semantic Memory', () => {
+    it('adds and searches semantic memories by vector', () => {
+      const embedding1 = [1, 0, 0, 0];
+      const embedding2 = [0, 1, 0, 0];
+      const queryEmbedding = [0.9, 0.1, 0, 0]; // closer to embedding1
+
+      memStore.addSemantic('agent-1', 'sm-1', 'The sky is blue', 'fact', embedding1);
+      memStore.addSemantic('agent-1', 'sm-2', 'Water is wet', 'fact', embedding2);
+
+      const results = memStore.searchSemantic('agent-1', queryEmbedding);
+      expect(results.length).toBe(2);
+      expect(results[0].id).toBe('sm-1'); // closer match
+      expect(results[0].score).toBeGreaterThan(results[1].score!);
+    });
+
+    it('touches semantic memory to update access stats', () => {
+      memStore.addSemantic('agent-1', 'sm-1', 'Test content', 'fact', [1, 0]);
+
+      memStore.touchSemantic('sm-1');
+      memStore.touchSemantic('sm-1');
+
+      const row = db
+        .prepare('SELECT access_count FROM semantic_memory WHERE id = ?')
+        .get('sm-1') as { access_count: number };
+      expect(row.access_count).toBe(2);
+    });
+  });
+
+  describe('Episodic Memory', () => {
+    it('adds and retrieves episodic memories', () => {
+      memStore.addEpisodic('agent-1', 'ep-1', 'Found a bug', { tick: 1 }, 0.8, 1);
+      memStore.addEpisodic('agent-1', 'ep-2', 'Fixed the bug', { tick: 2 }, 0.3, 2);
+
+      const episodes = memStore.getEpisodicByEntity('agent-1');
+      expect(episodes.length).toBe(2);
+      expect(episodes[0].episodeSummary).toBe('Fixed the bug'); // most recent first
+    });
+
+    it('searches episodic memories by vector', () => {
+      const emb1 = [1, 0, 0];
+      const emb2 = [0, 1, 0];
+
+      memStore.addEpisodic('agent-1', 'ep-1', 'Episode A', null, 0.5, 1, emb1);
+      memStore.addEpisodic('agent-1', 'ep-2', 'Episode B', null, 0.7, 2, emb2);
+
+      const results = memStore.searchEpisodic('agent-1', [0.9, 0.1, 0]);
+      expect(results.length).toBe(2);
+      expect(results[0].id).toBe('ep-1');
+    });
+  });
+
+  describe('Procedural Memory', () => {
+    it('adds and retrieves skills', () => {
+      memStore.addProcedural('agent-1', 'sk-1', 'deploy', 'Deploy to prod', [{ step: 1 }], 'learned');
+
+      const skills = memStore.getProceduralByEntity('agent-1');
+      expect(skills.length).toBe(1);
+      expect(skills[0].skillName).toBe('deploy');
+      expect(skills[0].source).toBe('learned');
+    });
+
+    it('updates procedural stats with EMA', () => {
+      memStore.addProcedural('agent-1', 'sk-1', 'test-skill', 'Test', [], 'learned');
+
+      memStore.updateProceduralStats('sk-1', true, 1.0);
+      memStore.updateProceduralStats('sk-1', true, 1.0);
+      memStore.updateProceduralStats('sk-1', false, 0.0);
+
+      const skill = memStore.getProceduralByName('agent-1', 'test-skill');
+      expect(skill).not.toBeNull();
+      expect(skill!.successCount).toBe(2);
+      expect(skill!.failureCount).toBe(1);
+      expect(skill!.avgReward).toBeGreaterThan(0);
+      expect(skill!.avgReward).toBeLessThan(1);
+    });
+
+    it('looks up skill by name', () => {
+      memStore.addProcedural('agent-1', 'sk-1', 'unique-skill', 'Desc', [], 'imported');
+
+      const skill = memStore.getProceduralByName('agent-1', 'unique-skill');
+      expect(skill).not.toBeNull();
+      expect(skill!.id).toBe('sk-1');
+
+      const missing = memStore.getProceduralByName('agent-1', 'nonexistent');
+      expect(missing).toBeNull();
+    });
+  });
+
+  describe('Entity Snapshots', () => {
+    it('saves and retrieves entity snapshots', () => {
+      // Need to create entity first for foreign key
+      db.prepare('INSERT INTO entities (id) VALUES (?)').run('agent-1');
+
+      const components = {
+        Identity: { role: 'worker' },
+        WorldModel: { beliefs: { key: 'value' } },
+      };
+
+      memStore.saveSnapshot('agent-1', components);
+
+      const snapshot = memStore.getLatestSnapshot('agent-1');
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.components).toEqual(components);
+    });
+
+    it('returns latest snapshot when multiple exist', () => {
+      db.prepare('INSERT INTO entities (id) VALUES (?)').run('agent-1');
+
+      memStore.saveSnapshot('agent-1', { v: 1 }, 1000);
+      memStore.saveSnapshot('agent-1', { v: 2 }, 2000);
+
+      const snapshot = memStore.getLatestSnapshot('agent-1');
+      expect(snapshot!.components).toEqual({ v: 2 });
+    });
+
+    it('gets all latest snapshots', () => {
+      db.prepare('INSERT INTO entities (id) VALUES (?)').run('a1');
+      db.prepare('INSERT INTO entities (id) VALUES (?)').run('a2');
+
+      memStore.saveSnapshot('a1', { data: 'first' });
+      memStore.saveSnapshot('a2', { data: 'second' });
+
+      const all = memStore.getAllLatestSnapshots();
+      expect(all.length).toBe(2);
+    });
+
+    it('returns null for missing snapshot', () => {
+      expect(memStore.getLatestSnapshot('nonexistent')).toBeNull();
+    });
+  });
+});

--- a/tests/systems/ooda.test.ts
+++ b/tests/systems/ooda.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Engine } from '../../src/ecs/engine.js';
+import { Store } from '../../src/store/db.js';
+import type { ModelProvider, ModelResponse } from '../../src/model/types.js';
+import type { Logger } from '../../src/util/logger.js';
+import { observe } from '../../src/systems/observe.js';
+import { orient } from '../../src/systems/orient.js';
+import { decide } from '../../src/systems/decide.js';
+import { act } from '../../src/systems/act.js';
+
+function mockProvider(response?: string): ModelProvider {
+  return {
+    async generate(): Promise<ModelResponse> {
+      return { content: response ?? '{}' };
+    },
+  };
+}
+
+function mockLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+    level: 'info',
+  } as unknown as Logger;
+}
+
+describe('ObserveSystem', () => {
+  let store: Store;
+  let engine: Engine;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+    engine = new Engine(store, mockProvider(), mockLogger());
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('collects observations from action results', async () => {
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'ActionResult', {
+      action: 'test-action',
+      success: true,
+      result: { data: 'hello' },
+      tick: 0,
+      timestamp: Date.now(),
+    });
+
+    await observe(engine, id);
+
+    const obs = engine.getComponent(id, 'Observation') as Record<string, unknown>;
+    expect(obs).not.toBeNull();
+    const observations = obs.observations as Array<Record<string, unknown>>;
+    expect(observations.length).toBeGreaterThan(0);
+    expect(observations.some((o) => o.source === 'action_result')).toBe(true);
+  });
+
+  it('collects inbox messages as observations', async () => {
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Inbox', {
+      messages: [
+        { from: 'other', to: id, content: 'hello', metadata: {}, timestamp: Date.now() },
+      ],
+    });
+
+    await observe(engine, id);
+
+    const obs = engine.getComponent(id, 'Observation') as Record<string, unknown>;
+    const observations = obs.observations as Array<Record<string, unknown>>;
+    expect(observations.some((o) => (o.source as string).startsWith('message:'))).toBe(true);
+
+    // Inbox should be cleared
+    const inbox = engine.getComponent(id, 'Inbox') as Record<string, unknown>;
+    expect((inbox.messages as unknown[]).length).toBe(0);
+  });
+
+  it('respects attention filter for sensor types', async () => {
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'AttentionFilter', {
+      priorities: [],
+      activeSensors: ['tool_output'],
+    });
+    engine.addComponent(id, 'Sensor', {
+      sensorType: 'file_watcher',
+      active: true,
+      config: { path: '/tmp' },
+    });
+
+    await observe(engine, id);
+
+    const obs = engine.getComponent(id, 'Observation') as Record<string, unknown>;
+    const observations = obs.observations as Array<Record<string, unknown>>;
+    // file_watcher sensor should be filtered out since only tool_output is active
+    expect(observations.filter((o) => o.source === 'file_watcher').length).toBe(0);
+  });
+
+  it('produces empty observations when nothing available', async () => {
+    const id = engine.createEntity('agent');
+
+    await observe(engine, id);
+
+    const obs = engine.getComponent(id, 'Observation') as Record<string, unknown>;
+    expect(obs).not.toBeNull();
+    expect((obs.observations as unknown[]).length).toBe(0);
+  });
+});
+
+describe('OrientSystem', () => {
+  let store: Store;
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('produces orientation with novelty score from model response', async () => {
+    const orientResponse = JSON.stringify({
+      situationFrame: 'Agent detected new pattern',
+      novelty: 0.8,
+      beliefUpdates: { pattern: 'detected' },
+      attentionShift: ['logs', 'metrics'],
+      implicitOptions: [{ action: 'investigate', confidence: 0.9, rationale: 'High novelty' }],
+    });
+
+    store = new Store(':memory:');
+    const engine = new Engine(store, mockProvider(orientResponse), mockLogger());
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Observation', {
+      observations: [{ source: 'test', data: 'new data', timestamp: Date.now() }],
+      tick: 1,
+    });
+    engine.addComponent(id, 'WorldModel', { beliefs: {}, lastUpdated: 0, updateCount: 0 });
+
+    await orient(engine, id);
+
+    const o = engine.getComponent(id, 'Orientation') as Record<string, unknown>;
+    expect(o).not.toBeNull();
+    expect(o.novelty).toBe(0.8);
+    expect(o.situationFrame).toBe('Agent detected new pattern');
+    expect((o.implicitOptions as unknown[]).length).toBe(1);
+
+    // World model should be updated
+    const wm = engine.getComponent(id, 'WorldModel') as Record<string, unknown>;
+    expect((wm.beliefs as Record<string, unknown>).pattern).toBe('detected');
+    expect(wm.updateCount).toBe(1);
+  });
+
+  it('produces low novelty with no observations', async () => {
+    store = new Store(':memory:');
+    const engine = new Engine(store, mockProvider(), mockLogger());
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Observation', { observations: [], tick: 1 });
+
+    await orient(engine, id);
+
+    const o = engine.getComponent(id, 'Orientation') as Record<string, unknown>;
+    expect(o.novelty).toBe(0);
+  });
+
+  it('updates attention filter (Boyd feedback loop)', async () => {
+    const orientResponse = JSON.stringify({
+      situationFrame: 'Shift focus',
+      novelty: 0.5,
+      attentionShift: ['network', 'cpu'],
+      implicitOptions: [],
+    });
+
+    store = new Store(':memory:');
+    const engine = new Engine(store, mockProvider(orientResponse), mockLogger());
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Observation', {
+      observations: [{ source: 'x', data: {}, timestamp: Date.now() }],
+      tick: 1,
+    });
+
+    await orient(engine, id);
+
+    const filter = engine.getComponent(id, 'AttentionFilter') as Record<string, unknown>;
+    expect(filter).not.toBeNull();
+    expect(filter.priorities).toEqual(['network', 'cpu']);
+  });
+});
+
+describe('DecideSystem', () => {
+  let store: Store;
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('takes fast path when novelty is low', async () => {
+    store = new Store(':memory:');
+    const engine = new Engine(store, mockProvider(), mockLogger());
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Orientation', {
+      situationFrame: 'Routine check',
+      novelty: 0.1,
+      attentionShift: [],
+      implicitOptions: [
+        { action: 'continue-monitoring', confidence: 0.95, rationale: 'Everything normal' },
+        { action: 'alert', confidence: 0.2, rationale: 'Precautionary' },
+      ],
+      tick: 1,
+    });
+
+    await decide(engine, id);
+
+    const d = engine.getComponent(id, 'Decision') as Record<string, unknown>;
+    expect(d).not.toBeNull();
+    expect(d.selectedAction).toBe('continue-monitoring');
+    expect(d.deliberate).toBe(false);
+  });
+
+  it('takes deliberate path when novelty is high', async () => {
+    const deliberateResponse = JSON.stringify({
+      selectedAction: 'escalate-to-operator',
+      rationale: 'Unprecedented situation requires human input',
+    });
+
+    store = new Store(':memory:');
+    const engine = new Engine(store, mockProvider(deliberateResponse), mockLogger());
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Orientation', {
+      situationFrame: 'Unknown anomaly detected',
+      novelty: 0.9,
+      attentionShift: [],
+      implicitOptions: [{ action: 'investigate', confidence: 0.5, rationale: 'Need more info' }],
+      tick: 1,
+    });
+
+    await decide(engine, id);
+
+    const d = engine.getComponent(id, 'Decision') as Record<string, unknown>;
+    expect(d.selectedAction).toBe('escalate-to-operator');
+    expect(d.deliberate).toBe(true);
+  });
+});
+
+describe('ActSystem', () => {
+  let store: Store;
+  let engine: Engine;
+
+  beforeEach(() => {
+    store = new Store(':memory:');
+    engine = new Engine(store, mockProvider(), mockLogger());
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('executes decided action and writes result', async () => {
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Decision', {
+      selectedAction: 'deploy-update',
+      rationale: 'Version is ready',
+      deliberate: true,
+      tick: 1,
+    });
+
+    await act(engine, id);
+
+    const result = engine.getComponent(id, 'ActionResult') as Record<string, unknown>;
+    expect(result).not.toBeNull();
+    expect(result.action).toBe('deploy-update');
+    expect(result.success).toBe(true);
+  });
+
+  it('handles no-op action', async () => {
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Decision', {
+      selectedAction: 'no-op',
+      rationale: 'Nothing to do',
+      deliberate: false,
+      tick: 1,
+    });
+
+    await act(engine, id);
+
+    const result = engine.getComponent(id, 'ActionResult') as Record<string, unknown>;
+    expect(result.action).toBe('no-op');
+    expect(result.success).toBe(true);
+    expect(result.result).toBeNull();
+  });
+
+  it('emits action:execute event', async () => {
+    const id = engine.createEntity('agent');
+    engine.addComponent(id, 'Decision', {
+      selectedAction: 'test-action',
+      rationale: 'testing',
+      deliberate: false,
+      tick: 1,
+    });
+
+    const handler = vi.fn();
+    engine.on('action:execute', handler);
+
+    await act(engine, id);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][0].data.action).toBe('test-action');
+  });
+});

--- a/tests/systems/spawn-messaging.test.ts
+++ b/tests/systems/spawn-messaging.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Engine } from '../../src/ecs/engine.js';
+import { Store } from '../../src/store/db.js';
+import type { ModelProvider, ModelResponse } from '../../src/model/types.js';
+import type { Logger } from '../../src/util/logger.js';
+import { createAgentSpawnSystem } from '../../src/systems/spawn.js';
+import { createInterAgentMessageSystem, flushMessages } from '../../src/systems/messaging.js';
+import type { ECSEvent } from '../../src/ecs/types.js';
+
+function mockProvider(): ModelProvider {
+  return {
+    async generate(): Promise<ModelResponse> {
+      return { content: 'mock' };
+    },
+  };
+}
+
+function mockLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+    level: 'info',
+  } as unknown as Logger;
+}
+
+describe('AgentSpawnSystem', () => {
+  let store: Store;
+  let engine: Engine;
+
+  beforeEach(async () => {
+    store = new Store(':memory:');
+    engine = new Engine(store, mockProvider(), mockLogger());
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('spawns a child agent with OodaAgent component', async () => {
+    const spawnSystem = createAgentSpawnSystem(engine);
+    const parentId = engine.createEntity('parent');
+
+    const spawned = vi.fn();
+    engine.on('agent:spawned', spawned);
+
+    const event: ECSEvent = {
+      type: 'agent:spawn',
+      entityId: parentId,
+      data: { role: 'worker', goals: ['complete task'] },
+      source: 'test',
+      timestamp: Date.now(),
+    };
+
+    // Call handleEvent directly to ensure async completes
+    await spawnSystem.handleEvent(event);
+
+    expect(spawned).toHaveBeenCalledOnce();
+    const childId = spawned.mock.calls[0][0].entityId;
+    expect(engine.entityExists(childId)).toBe(true);
+
+    const ooda = engine.getComponent(childId, 'OodaAgent');
+    expect(ooda).not.toBeNull();
+
+    const identity = engine.getComponent(childId, 'Identity') as Record<string, unknown>;
+    expect(identity.role).toBe('worker');
+    expect(identity.coreGoals).toEqual(['complete task']);
+  });
+
+  it('links parent and child via components', async () => {
+    const spawnSystem = createAgentSpawnSystem(engine);
+    const parentId = engine.createEntity('parent');
+
+    const spawned = vi.fn();
+    engine.on('agent:spawned', spawned);
+
+    await spawnSystem.handleEvent({
+      type: 'agent:spawn',
+      entityId: parentId,
+      data: { role: 'sub' },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    const childId = spawned.mock.calls[0][0].entityId;
+
+    const parentRef = engine.getComponent(childId, 'ParentAgent') as Record<string, unknown>;
+    expect(parentRef.parentEntityId).toBe(parentId);
+
+    const children = engine.getComponent(parentId, 'ChildAgents') as Record<string, unknown>;
+    expect((children.childEntityIds as string[])).toContain(childId);
+  });
+});
+
+describe('InterAgentMessageSystem', () => {
+  let store: Store;
+  let engine: Engine;
+
+  beforeEach(async () => {
+    store = new Store(':memory:');
+    engine = new Engine(store, mockProvider(), mockLogger());
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('delivers messages from outbox to inbox', () => {
+    const agentA = engine.createEntity('agent-a');
+    const agentB = engine.createEntity('agent-b');
+
+    engine.addComponent(agentA, 'Outbox', {
+      messages: [
+        { from: agentA, to: agentB, content: 'hello B', metadata: {}, timestamp: Date.now() },
+      ],
+    });
+    engine.addComponent(agentB, 'Inbox', { messages: [] });
+
+    flushMessages(engine);
+
+    const inbox = engine.getComponent(agentB, 'Inbox') as Record<string, unknown>;
+    const messages = inbox.messages as Array<Record<string, unknown>>;
+    expect(messages.length).toBe(1);
+    expect(messages[0].content).toBe('hello B');
+
+    // Outbox should be cleared
+    const outbox = engine.getComponent(agentA, 'Outbox') as Record<string, unknown>;
+    expect((outbox.messages as unknown[]).length).toBe(0);
+  });
+
+  it('handles direct message send via handleEvent', async () => {
+    const msgSystem = createInterAgentMessageSystem(engine);
+    const agentA = engine.createEntity('agent-a');
+    const agentB = engine.createEntity('agent-b');
+    engine.addComponent(agentB, 'Inbox', { messages: [] });
+
+    await msgSystem.handleEvent({
+      type: 'message:send',
+      entityId: agentA,
+      data: { from: agentA, to: agentB, content: 'direct msg', metadata: {}, timestamp: Date.now() },
+      source: 'test',
+      timestamp: Date.now(),
+    });
+
+    const inbox = engine.getComponent(agentB, 'Inbox') as Record<string, unknown>;
+    expect((inbox.messages as unknown[]).length).toBe(1);
+  });
+
+  it('warns when target entity does not exist', () => {
+    const agentA = engine.createEntity('agent-a');
+    engine.addComponent(agentA, 'Outbox', {
+      messages: [
+        { from: agentA, to: 'nonexistent', content: 'hello', metadata: {}, timestamp: Date.now() },
+      ],
+    });
+
+    // Should not throw
+    flushMessages(engine);
+  });
+});


### PR DESCRIPTION
Implements the full Boyd OODA loop as ECS systems (Observe, Orient, Decide, Act)
with Orient as the schwerpunkt — detecting world model violations, scoring novelty,
and feeding attention shifts back into Observe (implicit guidance loop). Adds
multi-level memory (semantic, episodic, procedural) backed by SQLite, autonomous
skill creation from successful action sequences, entity serialization for session
continuity, agent spawning, and inter-agent messaging. Includes ModelProvider
routing with fallback and latency tracking.

44 new tests covering all systems including Boyd correctness verification.

https://claude.ai/code/session_01LRyHN8VvD4S2rtvo3iK6g6